### PR TITLE
Reverse Log order

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-tactile

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-tactile

--- a/vue/myComponent.vue
+++ b/vue/myComponent.vue
@@ -104,7 +104,6 @@
                         splt.pop();
                     }
                     this.logs = splt.join('\n');
-                    this.logs.scrollTop = this.logs.scrollHeight;
                     setTimeout(()=>{this.showlogs();}, 1000);
                 });
             } else {

--- a/vue/myComponent.vue
+++ b/vue/myComponent.vue
@@ -101,7 +101,7 @@
                     this.logs = data + "\n" + this.logs;
                     let splt = this.logs.split('\n');
                     while (splt.length > 400){
-                        splt.shift();
+                        splt.pop();
                     }
                     this.logs = splt.join('\n');
                     this.logs.scrollTop = this.logs.scrollHeight;

--- a/vue/myComponent.vue
+++ b/vue/myComponent.vue
@@ -98,7 +98,7 @@
               fetch(url)
                 .then(response => response.text())
                 .then(data => {
-                    this.logs = data + "\n" + this.logs;
+                    this.logs = data+'\n'+this.logs;
                     let splt = this.logs.split('\n');
                     while (splt.length > 400){
                         splt.pop();

--- a/vue/myComponent.vue
+++ b/vue/myComponent.vue
@@ -104,6 +104,7 @@
                         splt.shift();
                     }
                     this.logs = splt.join('\n');
+                    this.logs.scrollTop = this.logs.scrollHeight;
                     setTimeout(()=>{this.showlogs();}, 1000);
                 });
             } else {

--- a/vue/myComponent.vue
+++ b/vue/myComponent.vue
@@ -98,7 +98,7 @@
               fetch(url)
                 .then(response => response.text())
                 .then(data => {
-                    this.logs += data;
+                    this.logs = data + "\n" + this.logs;
                     let splt = this.logs.split('\n');
                     while (splt.length > 400){
                         splt.shift();


### PR DESCRIPTION
This way, newly logged lines will be added on top, and over 400 will be popped of the bottom. 
This prevents scrolling to check current activities