### PR TITLE
Support for client device database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
-# testwebpages
-a test
+# OpenBekenIOT Web App
+
+This repo publishes a simple javascript webb app to
+
+https://openbekeniot.github.io/webapp/
+
+The code is in the gh-pages branch!
+
+
+The web app is initiated by a very simple webpage on the device at http://(IP)/app
+
+The address the device redirects to defaults to this repo, but there is a configuration on the dveice, so you can host locally on your LAN for more security, or even from the device itself (via the device filesystem if present).
+
+The app root page loads startup.js, which then loads VueJS and a SFC myComponent.vue, which is the guts of the web app.  Each page of the app is a separate SFC vuejs control.
+
+Features include OTA, device filesystem management, device configuration, logging, etc.
+
+
+## Device Database
+
+The webApp now supports client device database. Each device entry consists of the following fields:
+
+* name: (required) Device name
+* chip: (required) Chipset
+* board: (optional) Board
+* pins: (required) Pin configuration. The pin value can be
+    * PinRole;channel
+    * PinRole;channel;secondChannel
+* urls: (optional) Array of reference urls
+* flag: (optional) Optional operation flag passed to `CFG_SetFlag`, possible values are `LED_RAWCHANNELSMODE`, `BTN_INSTANTTOUCH`.
+* command: (optional) Value passed to `CFG_SetShortStartupCommand_AndExecuteNow`
+
+Available pin roles:
+* Relay
+* Relay_n
+* Button
+* Button_n
+* LED
+* LED_n
+* PWM
+* WifiLED
+* WifiLED_n
+* Btn_Tgl_All
+* Btn_Tgl_All_n
+* dInput
+* dInput_n
+* TglChanOnTgl
+* dInput_NoPullUp
+* dInput_NoPullUp_n
+* BL0937SEL
+* BL0937CF
+* BL0937CF1
+* ADC
+* SM2135DAT
+* SM2135CLK
+
+Sample:
+```
+  {
+    "name": "CasaLife CCT LED Downlight SMART-AL2017-TGTS",
+    "chip": "BK7231T",
+    "pins": {
+      "7": "PWM;0",
+      "8": "PWM;1"
+    },
+    "urls": [
+      "https://www.elektroda.com/rtvforum/viewtopic.php?p=20123466#20123466"
+    ],
+    "flag": "LED_RAWCHANNELSMODE"
+  }
+```
+
+## User Interface
+The new device selection interface will appear under `Config` tab if the device has been flashed with the supporting firmware version.
+
+* `Chipset`: the device list is initially filtered by the current chipset
+* `Device`: selecting a device will shows its details
+* `Copy Device Pins`: copies over the pin configuration
+* `Save Pins`: saves the pin configuration
+
+
+# Development
+
+Edit `indexlocal.html` to where `window.device` points at the test device.
+```
+        <script>
+            window.root = '/beken/';
+            window.device = 'http://192.168.1.176';
+        </script>
+        <script src="/beken/startup.js"></script>
+```
+
+The site content can be served through many ways including [nodejs](https://nodejs.org/en/).
+
+* Install [serve node](https://www.npmjs.com/package/serve)
+* Invoke `serve -l 80` from terminal
+* Navigate to `http://localhost/indexlocal`
+
+The web app page will fetch data from your test device.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Features include OTA, device filesystem management, device configuration, loggin
 
 The webApp now supports client device database. Each device entry consists of the following fields:
 
+* vendor: (required) Vendor
 * name: (required) Device name
+* model: (optional) Model number
 * chip: (required) Chipset
 * board: (optional) Board
 * pins: (required) Pin configuration. The pin value can be

--- a/README.md
+++ b/README.md
@@ -18,19 +18,26 @@ Features include OTA, device filesystem management, device configuration, loggin
 
 ## Device Database
 
-The webApp now supports client device database. Each device entry consists of the following fields:
+The webApp now supports client device database. 
 
-* vendor: (required) Vendor
-* name: (required) Device name
-* model: (optional) Model number
-* chip: (required) Chipset
-* board: (optional) Board
-* pins: (required) Pin configuration. The pin value can be
-    * PinRole;channel
-    * PinRole;channel;secondChannel
-* urls: (optional) Array of reference urls
-* flag: (optional) Optional operation flag passed to `CFG_SetFlag`, possible values are `LED_RAWCHANNELSMODE`, `BTN_INSTANTTOUCH`.
-* command: (optional) Value passed to `CFG_SetShortStartupCommand_AndExecuteNow`
+Each device entry consists of the following **required** fields:
+
+* vendor: Vendor
+* name: Device name
+* chip: Chipset
+* pins: Pin configuration mapping. The pin value can be *PinRole;channel* or *PinRole;channel;secondChannel*
+* image: Main image
+* wiki: Wiki url
+
+And these **optional** fields:
+* model: Device model
+* board: Board
+* product: Product url
+* urls: Reference urls
+* gallery: Gallery urls
+* flag: Device flag (see [new_pins.h](https://github.com/openshwprojects/OpenBK7231T_App/blob/4fd6a292d52146fa493f0a0d7c7069333cd12e5f/src/new_pins.h))
+* command: Startup command passed to `CFG_SetShortStartupCommand_AndExecuteNow`
+* keywords: Keywords
 
 Available pin roles:
 * Relay
@@ -59,16 +66,17 @@ Available pin roles:
 Sample:
 ```
   {
-    "name": "CasaLife CCT LED Downlight SMART-AL2017-TGTS",
+    "vendor": "CasaLife",
+    "name": "CCT LED Downlight",
+    "model": "SMART-AL2017-TGTS",
     "chip": "BK7231T",
     "pins": {
       "7": "PWM;0",
       "8": "PWM;1"
     },
-    "urls": [
-      "https://www.elektroda.com/rtvforum/viewtopic.php?p=20123466#20123466"
-    ],
-    "flag": "LED_RAWCHANNELSMODE"
+    "image": "https://obrazki.elektroda.pl/4181235400_1659263189.jpg",
+    "wiki": "https://www.elektroda.com/rtvforum/viewtopic.php?p=20123466#20123466",
+    "flag": 3
   }
 ```
 
@@ -86,10 +94,10 @@ The new device selection interface will appear under `Config` tab if the device 
 Edit `indexlocal.html` to where `window.device` points at the test device.
 ```
         <script>
-            window.root = '/beken/';
+            window.root = '';
             window.device = 'http://192.168.1.176';
         </script>
-        <script src="/beken/startup.js"></script>
+        <script src="startup.js"></script>
 ```
 
 The site content can be served through many ways including [nodejs](https://nodejs.org/en/).
@@ -99,3 +107,19 @@ The site content can be served through many ways including [nodejs](https://node
 * Navigate to `http://localhost/indexlocal`
 
 The web app page will fetch data from your test device.
+
+
+## device.json
+If you are using VSCode and plan on editing `devices.json`, then it can be validated against `schema.json` by adding this to your settings.
+
+```
+"json.schemas": [
+
+        {
+            "fileMatch": [
+                "/devices.json"
+            ],
+            "url": "./schema.json"
+        } 
+    ]
+```

--- a/devices.json
+++ b/devices.json
@@ -14,8 +14,8 @@
         "10": "Button;1",
         "26": "TglChanOnTgl;1"
       },
-      "image": "",
-      "wiki": ""
+      "image": "https://obrazki.elektroda.pl/5120493600_1650616045.jpg",
+      "wiki": "https://www.elektroda.com/rtvforum/topic3895572.html#20033093"
     },
     {
       "vendor": "Magic Home",
@@ -39,7 +39,7 @@
         "26": "Button;1"
       },
       "image": "https://obrazki.elektroda.pl/4822560000_1620736449.jpg",
-      "wiki": "https://www.elektroda.pl/rtvforum/topic3804553.html"
+      "wiki": "https://www.elektroda.com/rtvforum/topic3804553.html"
     },
 
     {
@@ -72,7 +72,7 @@
         "6": "PWM;5"
       },
       "image": "https://obrazki.elektroda.pl/1632162600_1647560633.jpg",
-      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3880540&highlight="
+      "wiki": "https://www.elektroda.com/rtvforum/topic3880540.html"
     },
 
     {
@@ -84,7 +84,7 @@
         "6": "Button;1"
       },
       "image": "https://obrazki.elektroda.pl/8055479400_1637246842.jpg",
-      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19743751#19743751"
+      "wiki": "https://www.elektroda.pl/rtvforum/topic3851807.html#19743751"
     },
 
     {
@@ -97,7 +97,7 @@
         "1": "Button;1"
       },
       "image": "https://obrazki.elektroda.pl/6506291700_1618394268.jpg",
-      "wiki": "https://www.elektroda.pl/rtvforum/topic3798114.html"
+      "wiki": "https://www.elektroda.com/rtvforum/topic3798114.html"
     },
 
     {
@@ -112,7 +112,7 @@
         "26": "PWM;5"
       },
       "image": "",
-      "wiki": ""
+      "wiki": "https://www.elektroda.com/rtvforum/topic3850712.html#19824097"
     },
 
     {
@@ -129,8 +129,8 @@
         "10": "LED;1",
         "24": "LED;2"
       },
-      "image": "",
-      "wiki": ""
+      "image": "https://obrazki.elektroda.pl/7584166600_1644156432.jpg",
+      "wiki": "https://www.elektroda.com/rtvforum/topic3866123-60.html#19867995"
     },
 
     {
@@ -144,9 +144,7 @@
       },
       "image": "",
       "wiki": "",
-      "urls": [
-        "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-cct-led-downlight_p0168694"
-      ]
+      "product": "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-cct-led-downlight_p0168694"
     },
 
     {
@@ -163,9 +161,7 @@
       },
       "image": "",
       "wiki": "",
-      "urls": [
-        "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-rgb-cct-led-downlight_p0168695"
-      ]
+      "product": "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-rgb-cct-led-downlight_p0168695"
     },
 
     {
@@ -193,7 +189,7 @@
         "26": "Relay_n;1"
       },
       "image": "https://obrazki.elektroda.pl/4822560000_1620736449.jpg",
-      "wiki": "https://www.elektroda.pl/rtvforum/topic3804553.html"
+      "wiki": "https://www.elektroda.com/rtvforum/topic3804553.html"
     },
 
     {
@@ -207,7 +203,7 @@
         "26": "Relay;1"
       },
       "image": "https://obrazki.elektroda.pl/4822560000_1620736449.jpg",
-      "wiki": "https://www.elektroda.pl/rtvforum/topic3804553.html"
+      "wiki": "https://www.elektroda.com/rtvforum/topic3804553.html"
     },
 
     {
@@ -221,7 +217,7 @@
         "26": "Relay;1"
       },
       "image": "https://obrazki.elektroda.pl/4822560000_1620736449.jpg",
-      "wiki": "https://www.elektroda.pl/rtvforum/topic3804553.html"
+      "wiki": "https://www.elektroda.com/rtvforum/topic3804553.html"
     },
 
     {
@@ -236,7 +232,7 @@
         "26": "Relay;1"
       },
       "image": "https://obrazki.elektroda.pl/6510354700_1649939521.jpg",
-      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3887748&highlight=",
+      "wiki": "https://www.elektroda.com/rtvforum/topic3887748.html",
       "command": "backlog startDriver BL0942; VREF 15987.125000; PREF -683.023987; IREF 272302.687500"
     },
 
@@ -250,7 +246,7 @@
         "8": "Relay;1"
       },
       "image": "https://obrazki.elektroda.pl/1094134100_1644544710.jpg",
-      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3874289&highlight="
+      "wiki": "https://www.elektroda.com/rtvforum/viewtopic.php?t=3874289"
     },
 
     {
@@ -277,8 +273,8 @@
         "6": "Relay_n;1",
         "10": "LED;1"
       },
-      "image": "",
-      "wiki": ""
+      "image": "https://obrazki.elektroda.pl/1094134100_1644544710.jpg",
+      "wiki": "https://www.elektroda.com/rtvforum/viewtopic.php?t=3874289"
     },
 
     {
@@ -293,8 +289,8 @@
         "26": "LED;2",
         "24": "Button;1"
       },
-      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19906670#19906670",
-      "image": "https://obrazki.elektroda.pl/6606464600_1642467157.jpg"
+      "image": "https://obrazki.elektroda.pl/6606464600_1642467157.jpg",
+      "wiki": "https://www.elektroda.com/rtvforum/viewtopic.php?p=19906670#19906670"
     },
 
     {
@@ -309,9 +305,7 @@
       },
       "image": "",
       "wiki": "",
-      "urls": [
-        "https://www.tokmanni.fi/alypistorasia-home-connect-ip20-6419860720456"
-      ]
+      "product": "https://www.tokmanni.fi/alypistorasia-home-connect-ip20-6419860720456"
     },
 
     {
@@ -447,11 +441,11 @@
         "25": "Relay_n;1"
       },
       "image": "https://obrazki.elektroda.pl/8563462300_1652196315.jpg",
-      "wiki": ""
+      "wiki": "https://www.elektroda.com/rtvforum/topic3892473.html#20014441"
     },
 
     {
-      "vendor": "Deta",
+      "vendor": "DETA",
       "name": "Smart Double Power Point Series 2",
       "model": "6922HA",
       "chip": "BK7231T",

--- a/devices.json
+++ b/devices.json
@@ -1,401 +1,403 @@
 [
-    {
-      "name": ""
-    },
-  
-    {
-      "name": "WiFi DIY Switch ZN268131",
-      "chip": "BK7231T",
-      "board": "WB2S",
-      "pins": {
-        "6": "Relay;1",
-        "7": "WifiLED_n;1",
-        "10": "Button;1",
-        "26": "TglChanOnTgl;1"
-      }
-    },
-  
-    {
-      "name": "Magic Home LED RGB IR Strip",
-      "chip": "BL602",
-      "pins": {
-        "4": "PWM;0",
-        "3": "PWM;1",
-        "21": "PWM;2"
-      },
-      "urls": ["https://www.elektroda.pl/rtvforum/topic3881416.html"]
-    },
-  
-    {
-      "name": "Tuya SmartSwitch SW01 16A",
-      "chip": "BK7231T",
-      "pins": {
-        "7": "Relay;1",
-        "26": "Button;1"
-      },
-      "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
-    },
-  
-    {
-      "name": "Tuya SmartLife 4CH 10A",
-      "chip": "BK7231T",
-      "pins": {
-        "7": "Button;1",
-        "8": "Button;2",
-        "9": "Button;3",
-        "1": "Button;4",
-        "14": "Relay;1",
-        "6": "Relay;2",
-        "24": "Relay;3",
-        "26": "Relay;4"
-      },
-      "urls": ["https://www.elektroda.pl/rtvforum/topic3822484.html"]
-    },
-  
-    {
-      "name": "uya E27 LED RGBCW 5PWMs",
-      "chip": "BK7231N",
-      "pins": {
-        "26": "PWM;1",
-        "8": "PWM;2",
-        "7": "PWM;3",
-        "9": "PWM;4",
-        "6": "PWM;5"
-      },
-      "urls": [
-        "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3880540&highlight="
-      ]
-    },
-  
-    {
-      "name": "IntelligentLife NF101A",
-      "chip": "BK7231T",
-      "pins": {
-        "24": "Relay;1",
-        "6": "Button;1"
-      },
-      "urls": [
-        "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19743751#19743751"
-      ]
-    },
-  
-    {
-      "name": "Tuya LED Dimmer Single Channel PWM",
-      "chip": "BK7231T",
-      "board": "WB3S",
-      "pins": {
-        "8": "PWM;1",
-        "1": "Button;1"
-      },
-      "urls": ["https://www.elektroda.pl/rtvforum/topic3798114.html"]
-    },
-  
-    {
-      "name": "Calex RGBWW LED Dimmer Five Channel PWM",
-      "chip": "BK7231S",
-      "pins": {
-        "7": "PWM;1",
-        "8": "PWM;2",
-        "6": "PWM;3",
-        "24": "PWM;4",
-        "26": "PWM;5"
-      }
-    },
-  
-    {
-      "name": "Calex UK power strip 900018.1 v1.0 UK",
-      "chip": "BK7231T",
-      "pins": {
-        "6": "Relay;5",
-        "7": "Relay;2",
-        "8": "Relay;3",
-        "9": "Relay;1",
-        "26": "Relay;4",
-        "14": "Button;1",
-        "10": "LED;1",
-        "24": "LED;2"
-      }
-    },
-  
-    {
-      "name": "Arlec CCT LED Downlight ALD029CHA",
-      "chip": "BK7231T",
-      "pins": {
-        "6": "PWM;4",
-        "24": "PWM;5"
-      },
-      "urls": [
-        "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-cct-led-downlight_p0168694"
-      ]
-    },
-  
-    {
-      "name": "Arlec RGB+CCT LED Downlight ALD092RHA",
-      "chip": "BK7231T",
-      "pins": {
-        "8": "PWM;1",
-        "7": "PWM;2",
-        "9": "PWM;3",
-        "6": "PWM;4",
-        "24": "PWM;5"
-      },
-      "urls": [
-        "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-rgb-cct-led-downlight_p0168695"
-      ]
-    },
-  
-    {
-      "name": "CasaLife CCT LED Downlight SMART-AL2017-TGTS",
-      "chip": "BK7231T",
-      "pins": {
-        "7": "PWM;0",
-        "8": "PWM;1"
-      },
-      "urls": [
-        "https://www.elektroda.com/rtvforum/viewtopic.php?p=20123466#20123466"
-      ]
-    },
-  
-    {
-      "name": "Nedis WIFIPO120FWT SmartPlug 16A",
-      "chip": "BK7231T",
-      "pins": {
-        "6": "LED;1",
-        "10": "Button;1",
-        "26": "Relay_n;1"
-      },
-      "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
-    },
-  
-    {
-      "name": "Nedis WIFIP130FWT SmartPlug 10A",
-      "chip": "BK7231T",
-      "pins": {
-        "6": "LED;1",
-        "10": "Button;1",
-        "26": "Relay;1"
-      },
-      "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
-    },
-  
-    {
-      "name": "Emax Home EDU8774 SmartPlug 16A",
-      "chip": "BK7231T",
-      "pins": {
-        "10": "Button;1",
-        "24": "LED_n;1",
-        "26": "Relay;1"
-      },
-      "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
-    },
-  
-    {
-      "name": "LSPA9 power metering plug BL0942 version",
-      "chip": "BK7231N",
-      "board": "CB2S",
-      "pins": {
-        "6": "Button;1",
-        "8": "WifiLED_n;1",
-        "26": "Relay;1"
-      },
-      "urls": [
-        "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3887748&highlight="
-      ]
-    },
-  
-    {
-      "name": "Qiachip Smart Switch",
-      "chip": "BK7231N",
-      "board": "CB2S",
-      "pins": {
-        "7": "Button;1",
-        "8": "Relay;1"
-      },
-      "urls": [
-        "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3874289&highlight="
-      ]
-    },
-  
-    {
-      "name": "KS 602 Touch Switch US",
-      "chip": "BK7231N",
-      "pins": {
-        "17": "Relay;1",
-        "26": "Button;1"
-      }
-    },
-  
-    {
-      "name": "QiaChip Smart Switch",
-      "chip": "BK7231T",
-      "board": "WB2S",
-      "pins": {
-        "7": "Button;1",
-        "6": "Relay_n;1",
-        "10": "LED;1"
-      }
-    },
-  
-    {
-      "name": "Prime SmartOutlet Outdoor 2x CostcovCCWFIO232PK",
-      "chip": "BK7231T",
-      "pins": {
-        "6": "Relay;1",
-        "7": "Relay;2",
-        "10": "LED;1",
-        "26": "LED;2",
-        "24": "Button;1"
-      },
-      "urls": [
-        "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19906670#19906670",
-        "https://obrazki.elektroda.pl/6606464600_1642467157.jpg"
-      ]
-    },
-  
-    {
-      "name": "Tuya Smart PFW02-G",
-      "chip": "BK7231T",
-      "pins": {
-        "24": "Relay_n;1",
-        "26": "Button;1",
-        "7": "LED;1"
-      },
-      "urls": [
-        "https://www.tokmanni.fi/alypistorasia-home-connect-ip20-6419860720456"
-      ]
-    },
-  
-    {
-      "name": "Avatar ASL04 5v LED strip",
-      "chip": "BK7231T",
-      "pins": {
-        "24": "PWM;1",
-        "8": "PWM;2",
-        "6": "PWM;3",
-        "7": "Button;1",
-        "9": "Button;2",
-        "14": "Button;3"
-      }
-    },
-  
-    {
-      "name": "Tuya Smart Wifi Switch 4 Gang",
-      "chip": "BK7231N",
-      "board": "CB3S",
-      "pins": {
-        "24": "Button;1",
-        "20": "Button;2",
-        "7": "Button;3",
-        "14": "Button;4",
-        "6": "Relay;1",
-        "8": "Relay;2",
-        "9": "Relay;3",
-        "26": "Relay;4",
-        "22": "WifiLED_n;1"
-      }
-    },
-  
-    {
-      "name": "LSC Smart Connect Plug",
-      "chip": "BK7231N",
-      "board": "CB2S",
-      "pins": {
-        "6": "LED;1",
-        "7": "Button;1",
-        "26": "Relay;1"
-      }
-    },
-  
-    {
-      "name": "DS-102 1 Gang Switch",
-      "chip": "BK7231T",
-      "board": "WB3S",
-      "pins": {
-        "1": "WifiLED;1",
-        "6": "Relay;1",
-        "10": "Button;1",
-        "26": "LED;1"
-      }
-    },
-  
-    {
-      "name": "Gosund Smart Switch SW5-A-V2.1",
-      "chip": "BK7231T",
-      "pins": {
-        "7": "WifiLED;1",
-        "14": "Relay;1",
-        "8": "Button;1",
-        "16": "LED_n;1"
-      },
-      "urls": [
-        "https://www.elektroda.com/rtvforum/viewtopic.php?p=20008969#20008969"
-      ]
-    },
-  
-    {
-      "name": "DS-102 2 Gang Switch",
-      "chip": "BK7231T",
-      "board": "WB3S",
-      "pins": {
-        "1": "WifiLED;1",
-        "6": "Relay;1",
-        "10": "Button;1",
-        "26": "LED;1",
-        "8": "Button;2",
-        "9": "Relay;2",
-        "11": "LED;2"
-      }
-    },
-  
-    {
-      "name": "DS-102 3 Gang Switch",
-      "chip": "BK7231T",
-      "board": "WB3S",
-      "pins": {
-        "1": "WifiLED;1",
-        "6": "Relay;1",
-        "24": "Button;1",
-        "14": "LED;1",
-        "9": "Relay;2",
-        "10": "Button;2",
-        "26": "LED;2",
-        "7": "Relay;3",
-        "8": "Button;3",
-        "11": "LED;3"
-      }
-    },
-  
-    {
-      "name": "Aliexpress socket 13A",
-      "chip": "BK7231N",
-      "board": "CB2S",
-      "pins": {
-        "6": "LED;0",
-        "7": "LED;1",
-        "8": "Button;0",
-        "24": "Relay_n;0",
-        "25": "Relay_n;1"
-      },
-      "urls": [
-        "https://obrazki.elektroda.pl/8563462300_1652196315.jpg",
-        "https://obrazki.elektroda.pl/8998188300_1652196330.jpg",
-        "https://obrazki.elektroda.pl/2281136200_1652196339.jpg",
-        "https://obrazki.elektroda.pl/1568452900_1652196348.jpg",
-        "https://obrazki.elektroda.pl/4600787700_1652196323.jpg"
-      ]
-    },
-  
-    {
-      "name": "Deta Smart Double Power Point 6922HA Series 2",
-      "chip": "BK7231T",
-      "pins": {
-        "6": "Relay;1",
-        "9": "WifiLED_n;1",
-        "14": "Button;1",
-        "24": "Button;2",
-        "26": "Relay;2"
-      },
-      "urls": ["https://obrazki.elektroda.pl/2789424600_1656890909.jpg"]
+  {
+    "name": ""
+  },
+
+  {
+    "name": "WiFi DIY Switch ZN268131",
+    "chip": "BK7231T",
+    "board": "WB2S",
+    "pins": {
+      "6": "Relay;1",
+      "7": "WifiLED_n;1",
+      "10": "Button;1",
+      "26": "TglChanOnTgl;1"
     }
-  ]
-  
+  },
+
+  {
+    "name": "Magic Home LED RGB IR Strip",
+    "chip": "BL602",
+    "pins": {
+      "4": "PWM;0",
+      "3": "PWM;1",
+      "21": "PWM;2"
+    },
+    "urls": ["https://www.elektroda.pl/rtvforum/topic3881416.html"]
+  },
+
+  {
+    "name": "Tuya SmartSwitch SW01 16A",
+    "chip": "BK7231T",
+    "pins": {
+      "7": "Relay;1",
+      "26": "Button;1"
+    },
+    "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
+  },
+
+  {
+    "name": "Tuya SmartLife 4CH 10A",
+    "chip": "BK7231T",
+    "pins": {
+      "7": "Button;1",
+      "8": "Button;2",
+      "9": "Button;3",
+      "1": "Button;4",
+      "14": "Relay;1",
+      "6": "Relay;2",
+      "24": "Relay;3",
+      "26": "Relay;4"
+    },
+    "urls": ["https://www.elektroda.pl/rtvforum/topic3822484.html"]
+  },
+
+  {
+    "name": "uya E27 LED RGBCW 5PWMs",
+    "chip": "BK7231N",
+    "pins": {
+      "26": "PWM;1",
+      "8": "PWM;2",
+      "7": "PWM;3",
+      "9": "PWM;4",
+      "6": "PWM;5"
+    },
+    "urls": [
+      "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3880540&highlight="
+    ]
+  },
+
+  {
+    "name": "IntelligentLife NF101A",
+    "chip": "BK7231T",
+    "pins": {
+      "24": "Relay;1",
+      "6": "Button;1"
+    },
+    "urls": [
+      "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19743751#19743751"
+    ]
+  },
+
+  {
+    "name": "Tuya LED Dimmer Single Channel PWM",
+    "chip": "BK7231T",
+    "board": "WB3S",
+    "pins": {
+      "8": "PWM;1",
+      "1": "Button;1"
+    },
+    "urls": ["https://www.elektroda.pl/rtvforum/topic3798114.html"]
+  },
+
+  {
+    "name": "Calex RGBWW LED Dimmer Five Channel PWM",
+    "chip": "BK7231S",
+    "pins": {
+      "7": "PWM;1",
+      "8": "PWM;2",
+      "6": "PWM;3",
+      "24": "PWM;4",
+      "26": "PWM;5"
+    }
+  },
+
+  {
+    "name": "Calex UK power strip 900018.1 v1.0 UK",
+    "chip": "BK7231T",
+    "pins": {
+      "6": "Relay;5",
+      "7": "Relay;2",
+      "8": "Relay;3",
+      "9": "Relay;1",
+      "26": "Relay;4",
+      "14": "Button;1",
+      "10": "LED;1",
+      "24": "LED;2"
+    }
+  },
+
+  {
+    "name": "Arlec CCT LED Downlight ALD029CHA",
+    "chip": "BK7231T",
+    "pins": {
+      "6": "PWM;4",
+      "24": "PWM;5"
+    },
+    "urls": [
+      "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-cct-led-downlight_p0168694"
+    ]
+  },
+
+  {
+    "name": "Arlec RGB+CCT LED Downlight ALD092RHA",
+    "chip": "BK7231T",
+    "pins": {
+      "8": "PWM;1",
+      "7": "PWM;2",
+      "9": "PWM;3",
+      "6": "PWM;4",
+      "24": "PWM;5"
+    },
+    "urls": [
+      "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-rgb-cct-led-downlight_p0168695"
+    ]
+  },
+
+  {
+    "name": "CasaLife CCT LED Downlight SMART-AL2017-TGTS",
+    "chip": "BK7231T",
+    "pins": {
+      "7": "PWM;0",
+      "8": "PWM;1"
+    },
+    "urls": [
+      "https://www.elektroda.com/rtvforum/viewtopic.php?p=20123466#20123466"
+    ],
+    "flag": "LED_RAWCHANNELSMODE"
+  },
+
+  {
+    "name": "Nedis WIFIPO120FWT SmartPlug 16A",
+    "chip": "BK7231T",
+    "pins": {
+      "6": "LED;1",
+      "10": "Button;1",
+      "26": "Relay_n;1"
+    },
+    "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
+  },
+
+  {
+    "name": "Nedis WIFIP130FWT SmartPlug 10A",
+    "chip": "BK7231T",
+    "pins": {
+      "6": "LED;1",
+      "10": "Button;1",
+      "26": "Relay;1"
+    },
+    "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
+  },
+
+  {
+    "name": "Emax Home EDU8774 SmartPlug 16A",
+    "chip": "BK7231T",
+    "pins": {
+      "10": "Button;1",
+      "24": "LED_n;1",
+      "26": "Relay;1"
+    },
+    "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
+  },
+
+  {
+    "name": "LSPA9 power metering plug BL0942 version",
+    "chip": "BK7231N",
+    "board": "CB2S",
+    "pins": {
+      "6": "Button;1",
+      "8": "WifiLED_n;1",
+      "26": "Relay;1"
+    },
+    "urls": [
+      "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3887748&highlight="
+    ],
+    "command": "backlog startDriver BL0942; VREF 15987.125000; PREF -683.023987; IREF 272302.687500"
+  },
+
+  {
+    "name": "Qiachip Smart Switch",
+    "chip": "BK7231N",
+    "board": "CB2S",
+    "pins": {
+      "7": "Button;1",
+      "8": "Relay;1"
+    },
+    "urls": [
+      "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3874289&highlight="
+    ]
+  },
+
+  {
+    "name": "KS 602 Touch Switch US",
+    "chip": "BK7231N",
+    "pins": {
+      "17": "Relay;1",
+      "26": "Button;1"
+    },
+    "flag": "BTN_INSTANTTOUCH"
+  },
+
+  {
+    "name": "QiaChip Smart Switch",
+    "chip": "BK7231T",
+    "board": "WB2S",
+    "pins": {
+      "7": "Button;1",
+      "6": "Relay_n;1",
+      "10": "LED;1"
+    }
+  },
+
+  {
+    "name": "Prime SmartOutlet Outdoor 2x CostcovCCWFIO232PK",
+    "chip": "BK7231T",
+    "pins": {
+      "6": "Relay;1",
+      "7": "Relay;2",
+      "10": "LED;1",
+      "26": "LED;2",
+      "24": "Button;1"
+    },
+    "urls": [
+      "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19906670#19906670",
+      "https://obrazki.elektroda.pl/6606464600_1642467157.jpg"
+    ]
+  },
+
+  {
+    "name": "Tuya Smart PFW02-G",
+    "chip": "BK7231T",
+    "pins": {
+      "24": "Relay_n;1",
+      "26": "Button;1",
+      "7": "LED;1"
+    },
+    "urls": [
+      "https://www.tokmanni.fi/alypistorasia-home-connect-ip20-6419860720456"
+    ]
+  },
+
+  {
+    "name": "Avatar ASL04 5v LED strip",
+    "chip": "BK7231T",
+    "pins": {
+      "24": "PWM;1",
+      "8": "PWM;2",
+      "6": "PWM;3",
+      "7": "Button;1",
+      "9": "Button;2",
+      "14": "Button;3"
+    }
+  },
+
+  {
+    "name": "Tuya Smart Wifi Switch 4 Gang",
+    "chip": "BK7231N",
+    "board": "CB3S",
+    "pins": {
+      "24": "Button;1",
+      "20": "Button;2",
+      "7": "Button;3",
+      "14": "Button;4",
+      "6": "Relay;1",
+      "8": "Relay;2",
+      "9": "Relay;3",
+      "26": "Relay;4",
+      "22": "WifiLED_n;1"
+    }
+  },
+
+  {
+    "name": "LSC Smart Connect Plug",
+    "chip": "BK7231N",
+    "board": "CB2S",
+    "pins": {
+      "6": "LED;1",
+      "7": "Button;1",
+      "26": "Relay;1"
+    }
+  },
+
+  {
+    "name": "DS-102 1 Gang Switch",
+    "chip": "BK7231T",
+    "board": "WB3S",
+    "pins": {
+      "1": "WifiLED;1",
+      "6": "Relay;1",
+      "10": "Button;1",
+      "26": "LED;1"
+    }
+  },
+
+  {
+    "name": "Gosund Smart Switch SW5-A-V2.1",
+    "chip": "BK7231T",
+    "pins": {
+      "7": "WifiLED;1",
+      "14": "Relay;1",
+      "8": "Button;1",
+      "16": "LED_n;1"
+    },
+    "urls": [
+      "https://www.elektroda.com/rtvforum/viewtopic.php?p=20008969#20008969"
+    ]
+  },
+
+  {
+    "name": "DS-102 2 Gang Switch",
+    "chip": "BK7231T",
+    "board": "WB3S",
+    "pins": {
+      "1": "WifiLED;1",
+      "6": "Relay;1",
+      "10": "Button;1",
+      "26": "LED;1",
+      "8": "Button;2",
+      "9": "Relay;2",
+      "11": "LED;2"
+    }
+  },
+
+  {
+    "name": "DS-102 3 Gang Switch",
+    "chip": "BK7231T",
+    "board": "WB3S",
+    "pins": {
+      "1": "WifiLED;1",
+      "6": "Relay;1",
+      "24": "Button;1",
+      "14": "LED;1",
+      "9": "Relay;2",
+      "10": "Button;2",
+      "26": "LED;2",
+      "7": "Relay;3",
+      "8": "Button;3",
+      "11": "LED;3"
+    }
+  },
+
+  {
+    "name": "AliExpress socket 13A",
+    "chip": "BK7231N",
+    "board": "CB2S",
+    "pins": {
+      "6": "LED;0",
+      "7": "LED;1",
+      "8": "Button;0;1",
+      "24": "Relay_n;0",
+      "25": "Relay_n;1"
+    },
+    "urls": [
+      "https://obrazki.elektroda.pl/8563462300_1652196315.jpg",
+      "https://obrazki.elektroda.pl/8998188300_1652196330.jpg",
+      "https://obrazki.elektroda.pl/2281136200_1652196339.jpg",
+      "https://obrazki.elektroda.pl/1568452900_1652196348.jpg",
+      "https://obrazki.elektroda.pl/4600787700_1652196323.jpg"
+    ]
+  },
+
+  {
+    "name": "Deta Smart Double Power Point 6922HA Series 2",
+    "chip": "BK7231T",
+    "pins": {
+      "6": "Relay;1",
+      "9": "WifiLED_n;1",
+      "14": "Button;1",
+      "24": "Button;2",
+      "26": "Relay;2"
+    },
+    "urls": ["https://obrazki.elektroda.pl/2789424600_1656890909.jpg"]
+  }
+]

--- a/devices.json
+++ b/devices.json
@@ -458,6 +458,51 @@
       },
       "image": "https://obrazki.elektroda.pl/2789424600_1656890909.jpg",
       "wiki": ""
+    },
+
+    {
+      "vendor": "Enbrighten",
+      "name": "WiFi Switch",
+      "model": "WFD4103",
+      "chip": "BK7231T",
+      "board": "WB2S",
+      "pins": {
+        "7": "LED_n;1",
+        "24": "Relay;1",
+        "26": "Btn;1"
+      },
+      "image": "https://obrazki.elektroda.pl/1036592500_1659877616.jpg",
+      "wiki": "https://www.elektroda.com/rtvforum/topic3911041.html#20133554",
+      "product": "https://enbrightenme.com/enbrighten-indoor-plug-in-mini-wifi-smart-switch-2-pack-white"
+    },
+
+    {
+      "vendor": "Sonoff",
+      "name": "MINI R3 Smart Switch",
+      "model": "MiniR3",
+      "chip": "BL602",
+      "pins": {
+        "1": "WifiLED_n;1",
+        "5": "Btn;1",
+        "22": "relay;1"
+      },
+      "image": "https://static.elektroda.pl/attach/thumb/3_1141202.jpg",
+      "wiki": "https://www.elektroda.com/rtvforum/topic3889041-120.html#20129282",
+      "product": "https://sonoff.tech/product/minir3"
+    },
+
+    {
+      "vendor": "Aubess",
+      "name": "Mini Smart Switch 16A",
+      "chip": "BK7231N",
+      "pins": {
+        "6": "LED_n;1",
+        "8": "Btn;1",
+        "14": "Btn;1",
+        "15": "relay;1"
+      },
+      "image": "https://obrazki.elektroda.pl/6209806600_1660573904.jpg",
+      "wiki": "https://www.elektroda.com/rtvforum/topic3912748.html#20145042"
     }
   ]
 }

--- a/devices.json
+++ b/devices.json
@@ -1,447 +1,469 @@
-[
-  {
-    "name": ""
-  },
+{
+  "version": 0.1,
+  "devices": [
+    {
+      "vendor": "Generic",
+      "name": "WiFi DIY Switch",
+      "model": "ZN268131",
+      "chip": "BK7231T",
+      "board": "WB2S",
+      "keywords": ["switch"],
+      "pins": {
+        "6": "Relay;1",
+        "7": "WifiLED_n;1",
+        "10": "Button;1",
+        "26": "TglChanOnTgl;1"
+      },
+      "image": "",
+      "wiki": ""
+    },
+    {
+      "vendor": "Magic Home",
+      "name": "LED RGB IR Strip",
+      "chip": "BL602",
+      "pins": {
+        "4": "PWM;0",
+        "3": "PWM;1",
+        "21": "PWM;2"
+      },
+      "image": "https://obrazki.elektroda.pl/3591447000_1647901952.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/topic3881416.html"
+    },
 
-  {
-    "vendor": "Generic",
-    "name": "WiFi DIY Switch",
-    "model": "ZN268131",
-    "chip": "BK7231T",
-    "board": "WB2S",
-    "pins": {
-      "6": "Relay;1",
-      "7": "WifiLED_n;1",
-      "10": "Button;1",
-      "26": "TglChanOnTgl;1"
+    {
+      "vendor": "Tuya",
+      "name": "SmartSwitch SW01 16A",
+      "chip": "BK7231T",
+      "pins": {
+        "7": "Relay;1",
+        "26": "Button;1"
+      },
+      "image": "https://obrazki.elektroda.pl/4822560000_1620736449.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/topic3804553.html"
+    },
+
+    {
+      "vendor": "Tuya",
+      "name": "SmartLife 4CH 10A",
+      "chip": "BK7231T",
+      "pins": {
+        "7": "Button;1",
+        "8": "Button;2",
+        "9": "Button;3",
+        "1": "Button;4",
+        "14": "Relay;1",
+        "6": "Relay;2",
+        "24": "Relay;3",
+        "26": "Relay;4"
+      },
+      "image": "https://obrazki.elektroda.pl/6864388200_1628112812.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/topic3822484.html"
+    },
+
+    {
+      "vendor": "Tuya",
+      "name": "E27 LED RGBCW 5PWMs",
+      "chip": "BK7231N",
+      "pins": {
+        "26": "PWM;1",
+        "8": "PWM;2",
+        "7": "PWM;3",
+        "9": "PWM;4",
+        "6": "PWM;5"
+      },
+      "image": "https://obrazki.elektroda.pl/1632162600_1647560633.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3880540&highlight="
+    },
+
+    {
+      "vendor": "Intelligent Life",
+      "name": "NF101A",
+      "chip": "BK7231T",
+      "pins": {
+        "24": "Relay;1",
+        "6": "Button;1"
+      },
+      "image": "https://obrazki.elektroda.pl/8055479400_1637246842.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19743751#19743751"
+    },
+
+    {
+      "vendor": "Tuya",
+      "name": "LED Dimmer Single Channel PWM",
+      "chip": "BK7231T",
+      "board": "WB3S",
+      "pins": {
+        "8": "PWM;1",
+        "1": "Button;1"
+      },
+      "image": "https://obrazki.elektroda.pl/6506291700_1618394268.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/topic3798114.html"
+    },
+
+    {
+      "vendor": "Calex",
+      "name": "RGBWW LED Dimmer Five Channel PWM",
+      "chip": "BK7231S",
+      "pins": {
+        "7": "PWM;1",
+        "8": "PWM;2",
+        "6": "PWM;3",
+        "24": "PWM;4",
+        "26": "PWM;5"
+      },
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "Calex",
+      "name": "UK power strip 900018.1 v1.0 UK",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "Relay;5",
+        "7": "Relay;2",
+        "8": "Relay;3",
+        "9": "Relay;1",
+        "26": "Relay;4",
+        "14": "Button;1",
+        "10": "LED;1",
+        "24": "LED;2"
+      },
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "Arlec",
+      "name": "CCT LED Downlight",
+      "model": "ALD029CHA",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "PWM;4",
+        "24": "PWM;5"
+      },
+      "image": "",
+      "wiki": "",
+      "urls": [
+        "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-cct-led-downlight_p0168694"
+      ]
+    },
+
+    {
+      "vendor": "Arlec",
+      "name": "RGB+CCT LED Downlight",
+      "model": "ALD092RHA",
+      "chip": "BK7231T",
+      "pins": {
+        "8": "PWM;1",
+        "7": "PWM;2",
+        "9": "PWM;3",
+        "6": "PWM;4",
+        "24": "PWM;5"
+      },
+      "image": "",
+      "wiki": "",
+      "urls": [
+        "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-rgb-cct-led-downlight_p0168695"
+      ]
+    },
+
+    {
+      "vendor": "CasaLife",
+      "name": "CCT LED Downlight",
+      "model": "SMART-AL2017-TGTS",
+      "chip": "BK7231T",
+      "pins": {
+        "7": "PWM;0",
+        "8": "PWM;1"
+      },
+      "image": "https://obrazki.elektroda.pl/4181235400_1659263189.jpg",
+      "wiki": "https://www.elektroda.com/rtvforum/viewtopic.php?p=20123466#20123466",
+      "flag": "LED_RAWCHANNELSMODE"
+    },
+
+    {
+      "vendor": "Nedis",
+      "name": "SmartPlug 16A",
+      "model": "WIFIPO120FWT",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "LED;1",
+        "10": "Button;1",
+        "26": "Relay_n;1"
+      },
+      "image": "https://obrazki.elektroda.pl/4822560000_1620736449.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/topic3804553.html"
+    },
+
+    {
+      "vendor": "Nedis",
+      "name": "SmartPlug 10A",
+      "model": "WIFIP130FWT",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "LED;1",
+        "10": "Button;1",
+        "26": "Relay;1"
+      },
+      "image": "https://obrazki.elektroda.pl/4822560000_1620736449.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/topic3804553.html"
+    },
+
+    {
+      "vendor": "Emax",
+      "name": "Home SmartPlug 16A",
+      "model": "EDU8774",
+      "chip": "BK7231T",
+      "pins": {
+        "10": "Button;1",
+        "24": "LED_n;1",
+        "26": "Relay;1"
+      },
+      "image": "https://obrazki.elektroda.pl/4822560000_1620736449.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/topic3804553.html"
+    },
+
+    {
+      "vendor": "ELIVCO",
+      "name": "Power metering plug BL0942 version",
+      "model": "LSPA9",
+      "chip": "BK7231N",
+      "board": "CB2S",
+      "pins": {
+        "6": "Button;1",
+        "8": "WifiLED_n;1",
+        "26": "Relay;1"
+      },
+      "image": "https://obrazki.elektroda.pl/6510354700_1649939521.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3887748&highlight=",
+      "command": "backlog startDriver BL0942; VREF 15987.125000; PREF -683.023987; IREF 272302.687500"
+    },
+
+    {
+      "vendor": "QiaChip",
+      "name": "Smart Switch",
+      "chip": "BK7231N",
+      "board": "CB2S",
+      "pins": {
+        "7": "Button;1",
+        "8": "Relay;1"
+      },
+      "image": "https://obrazki.elektroda.pl/1094134100_1644544710.jpg",
+      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3874289&highlight="
+    },
+
+    {
+      "vendor": "Hidin Tech",
+      "name": "Touch Switch US",
+      "model": "KS602",
+      "chip": "BK7231N",
+      "pins": {
+        "17": "Relay;1",
+        "26": "Button;1"
+      },
+      "flag": "BTN_INSTANTTOUCH",
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "QiaChip",
+      "name": "Smart Switch",
+      "chip": "BK7231T",
+      "board": "WB2S",
+      "pins": {
+        "7": "Button;1",
+        "6": "Relay_n;1",
+        "10": "LED;1"
+      },
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "Prime",
+      "name": "SmartOutlet Outdoor 2x Costco",
+      "model": "CCWFIO232PK",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "Relay;1",
+        "7": "Relay;2",
+        "10": "LED;1",
+        "26": "LED;2",
+        "24": "Button;1"
+      },
+      "wiki": "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19906670#19906670",
+      "image": "https://obrazki.elektroda.pl/6606464600_1642467157.jpg"
+    },
+
+    {
+      "vendor": "Tuya",
+      "name": "Smart",
+      "model": "PFW02-G",
+      "chip": "BK7231T",
+      "pins": {
+        "24": "Relay_n;1",
+        "26": "Button;1",
+        "7": "LED;1"
+      },
+      "image": "",
+      "wiki": "",
+      "urls": [
+        "https://www.tokmanni.fi/alypistorasia-home-connect-ip20-6419860720456"
+      ]
+    },
+
+    {
+      "vendor": "Avatar",
+      "name": "5v LED strip",
+      "model": "ASL04",
+      "chip": "BK7231T",
+      "pins": {
+        "24": "PWM;1",
+        "8": "PWM;2",
+        "6": "PWM;3",
+        "7": "Button;1",
+        "9": "Button;2",
+        "14": "Button;3"
+      },
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "Tuya",
+      "name": "Smart Wifi Switch 4 Gang",
+      "chip": "BK7231N",
+      "board": "CB3S",
+      "pins": {
+        "24": "Button;1",
+        "20": "Button;2",
+        "7": "Button;3",
+        "14": "Button;4",
+        "6": "Relay;1",
+        "8": "Relay;2",
+        "9": "Relay;3",
+        "26": "Relay;4",
+        "22": "WifiLED_n;1"
+      },
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "LSC",
+      "name": "Smart Connect Plug",
+      "chip": "BK7231N",
+      "board": "CB2S",
+      "pins": {
+        "6": "LED;1",
+        "7": "Button;1",
+        "26": "Relay;1"
+      },
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "DS-102",
+      "name": "1 Gang Switch",
+      "chip": "BK7231T",
+      "board": "WB3S",
+      "pins": {
+        "1": "WifiLED;1",
+        "6": "Relay;1",
+        "10": "Button;1",
+        "26": "LED;1"
+      },
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "Gosund",
+      "name": "Smart Switch",
+      "model": "SW5-A-V2.1",
+      "chip": "BK7231T",
+      "pins": {
+        "7": "WifiLED;1",
+        "14": "Relay;1",
+        "8": "Button;1",
+        "16": "LED_n;1"
+      },
+      "image": "",
+      "wiki": "https://www.elektroda.com/rtvforum/viewtopic.php?p=20008969#20008969"
+    },
+
+    {
+      "vendor": "DS-102",
+      "name": "2 Gang Switch",
+      "chip": "BK7231T",
+      "board": "WB3S",
+      "pins": {
+        "1": "WifiLED;1",
+        "6": "Relay;1",
+        "10": "Button;1",
+        "26": "LED;1",
+        "8": "Button;2",
+        "9": "Relay;2",
+        "11": "LED;2"
+      },
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "DS-102",
+      "name": "3 Gang Switch",
+      "chip": "BK7231T",
+      "board": "WB3S",
+      "pins": {
+        "1": "WifiLED;1",
+        "6": "Relay;1",
+        "24": "Button;1",
+        "14": "LED;1",
+        "9": "Relay;2",
+        "10": "Button;2",
+        "26": "LED;2",
+        "7": "Relay;3",
+        "8": "Button;3",
+        "11": "LED;3"
+      },
+      "image": "",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "AliExpress",
+      "name": "Socket 13A",
+      "chip": "BK7231N",
+      "board": "CB2S",
+      "pins": {
+        "6": "LED;0",
+        "7": "LED;1",
+        "8": "Button;0;1",
+        "24": "Relay_n;0",
+        "25": "Relay_n;1"
+      },
+      "image": "https://obrazki.elektroda.pl/8563462300_1652196315.jpg",
+      "wiki": ""
+    },
+
+    {
+      "vendor": "Deta",
+      "name": "Smart Double Power Point Series 2",
+      "model": "6922HA",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "Relay;1",
+        "9": "WifiLED_n;1",
+        "14": "Button;1",
+        "24": "Button;2",
+        "26": "Relay;2"
+      },
+      "image": "https://obrazki.elektroda.pl/2789424600_1656890909.jpg",
+      "wiki": ""
     }
-  },
-
-  {
-    "vendor": "Magic Home",
-    "name": "LED RGB IR Strip",
-    "chip": "BL602",
-    "pins": {
-      "4": "PWM;0",
-      "3": "PWM;1",
-      "21": "PWM;2"
-    },
-    "urls": ["https://www.elektroda.pl/rtvforum/topic3881416.html"]
-  },
-
-  {
-    "vendor": "Tuya",
-    "name": "SmartSwitch SW01 16A",
-    "chip": "BK7231T",
-    "pins": {
-      "7": "Relay;1",
-      "26": "Button;1"
-    },
-    "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
-  },
-
-  {
-    "vendor": "Tuya",
-    "name": "SmartLife 4CH 10A",
-    "chip": "BK7231T",
-    "pins": {
-      "7": "Button;1",
-      "8": "Button;2",
-      "9": "Button;3",
-      "1": "Button;4",
-      "14": "Relay;1",
-      "6": "Relay;2",
-      "24": "Relay;3",
-      "26": "Relay;4"
-    },
-    "urls": ["https://www.elektroda.pl/rtvforum/topic3822484.html"]
-  },
-
-  {
-    "vendor": "Tuya",
-    "name": "E27 LED RGBCW 5PWMs",
-    "chip": "BK7231N",
-    "pins": {
-      "26": "PWM;1",
-      "8": "PWM;2",
-      "7": "PWM;3",
-      "9": "PWM;4",
-      "6": "PWM;5"
-    },
-    "urls": [
-      "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3880540&highlight="
-    ]
-  },
-
-  {
-    "vendor": "Intelligent Life",
-    "name": "NF101A",
-    "chip": "BK7231T",
-    "pins": {
-      "24": "Relay;1",
-      "6": "Button;1"
-    },
-    "urls": [
-      "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19743751#19743751"
-    ]
-  },
-
-  {
-    "vendor": "Tuya",
-    "name": "LED Dimmer Single Channel PWM",
-    "chip": "BK7231T",
-    "board": "WB3S",
-    "pins": {
-      "8": "PWM;1",
-      "1": "Button;1"
-    },
-    "urls": ["https://www.elektroda.pl/rtvforum/topic3798114.html"]
-  },
-
-  {
-    "vendor": "Calex",
-    "name": "RGBWW LED Dimmer Five Channel PWM",
-    "chip": "BK7231S",
-    "pins": {
-      "7": "PWM;1",
-      "8": "PWM;2",
-      "6": "PWM;3",
-      "24": "PWM;4",
-      "26": "PWM;5"
-    }
-  },
-
-  {
-    "vendor": "Calex",
-    "name": "UK power strip 900018.1 v1.0 UK",
-    "chip": "BK7231T",
-    "pins": {
-      "6": "Relay;5",
-      "7": "Relay;2",
-      "8": "Relay;3",
-      "9": "Relay;1",
-      "26": "Relay;4",
-      "14": "Button;1",
-      "10": "LED;1",
-      "24": "LED;2"
-    }
-  },
-
-  {
-    "vendor": "Arlec",
-    "name": "CCT LED Downlight",
-    "model": "ALD029CHA",
-    "chip": "BK7231T",
-    "pins": {
-      "6": "PWM;4",
-      "24": "PWM;5"
-    },
-    "urls": [
-      "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-cct-led-downlight_p0168694"
-    ]
-  },
-
-  {
-    "vendor": "Arlec",
-    "name": "RGB+CCT LED Downlight",
-    "model": "ALD092RHA",
-    "chip": "BK7231T",
-    "pins": {
-      "8": "PWM;1",
-      "7": "PWM;2",
-      "9": "PWM;3",
-      "6": "PWM;4",
-      "24": "PWM;5"
-    },
-    "urls": [
-      "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-rgb-cct-led-downlight_p0168695"
-    ]
-  },
-
-  {
-    "vendor": "CasaLife",
-    "name": "CCT LED Downlight",
-    "model": "SMART-AL2017-TGTS",
-    "chip": "BK7231T",
-    "pins": {
-      "7": "PWM;0",
-      "8": "PWM;1"
-    },
-    "urls": [
-      "https://www.elektroda.com/rtvforum/viewtopic.php?p=20123466#20123466"
-    ],
-    "flag": "LED_RAWCHANNELSMODE"
-  },
-
-  {
-    "vendor": "Nedis",
-    "name": "SmartPlug 16A",
-    "model": "WIFIPO120FWT",
-    "chip": "BK7231T",
-    "pins": {
-      "6": "LED;1",
-      "10": "Button;1",
-      "26": "Relay_n;1"
-    },
-    "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
-  },
-
-  {
-    "vendor": "Nedis",
-    "name": "SmartPlug 10A",
-    "model": "WIFIP130FWT",
-    "chip": "BK7231T",
-    "pins": {
-      "6": "LED;1",
-      "10": "Button;1",
-      "26": "Relay;1"
-    },
-    "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
-  },
-
-  {
-    "vendor": "Emax",
-    "name": "Home SmartPlug 16A",
-    "model": "EDU8774",
-    "chip": "BK7231T",
-    "pins": {
-      "10": "Button;1",
-      "24": "LED_n;1",
-      "26": "Relay;1"
-    },
-    "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
-  },
-
-  {
-    "vendor": "ELIVCO",
-    "name": "Power metering plug BL0942 version",
-    "model": "LSPA9",
-    "chip": "BK7231N",
-    "board": "CB2S",
-    "pins": {
-      "6": "Button;1",
-      "8": "WifiLED_n;1",
-      "26": "Relay;1"
-    },
-    "urls": [
-      "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3887748&highlight="
-    ],
-    "command": "backlog startDriver BL0942; VREF 15987.125000; PREF -683.023987; IREF 272302.687500"
-  },
-
-  {
-    "vendor": "QiaChip",
-    "name": "Smart Switch",
-    "chip": "BK7231N",
-    "board": "CB2S",
-    "pins": {
-      "7": "Button;1",
-      "8": "Relay;1"
-    },
-    "urls": [
-      "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3874289&highlight="
-    ]
-  },
-
-  {
-    "vendor": "Hidin Tech",
-    "name": "Touch Switch US",
-    "model": "KS602",
-    "chip": "BK7231N",
-    "pins": {
-      "17": "Relay;1",
-      "26": "Button;1"
-    },
-    "flag": "BTN_INSTANTTOUCH"
-  },
-
-  {
-    "vendor": "QiaChip",
-    "name": "Smart Switch",
-    "chip": "BK7231T",
-    "board": "WB2S",
-    "pins": {
-      "7": "Button;1",
-      "6": "Relay_n;1",
-      "10": "LED;1"
-    }
-  },
-
-  {
-    "vendor": "Prime",
-    "name": "SmartOutlet Outdoor 2x Costco",
-    "model": "CCWFIO232PK",
-    "chip": "BK7231T",
-    "pins": {
-      "6": "Relay;1",
-      "7": "Relay;2",
-      "10": "LED;1",
-      "26": "LED;2",
-      "24": "Button;1"
-    },
-    "urls": [
-      "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19906670#19906670",
-      "https://obrazki.elektroda.pl/6606464600_1642467157.jpg"
-    ]
-  },
-
-  {
-    "vendor": "Tuya",
-    "name": "Smart",
-    "model": "PFW02-G",
-    "chip": "BK7231T",
-    "pins": {
-      "24": "Relay_n;1",
-      "26": "Button;1",
-      "7": "LED;1"
-    },
-    "urls": [
-      "https://www.tokmanni.fi/alypistorasia-home-connect-ip20-6419860720456"
-    ]
-  },
-
-  {
-    "vendor": "Avatar",
-    "name": "5v LED strip",
-    "model": "ASL04",
-    "chip": "BK7231T",
-    "pins": {
-      "24": "PWM;1",
-      "8": "PWM;2",
-      "6": "PWM;3",
-      "7": "Button;1",
-      "9": "Button;2",
-      "14": "Button;3"
-    }
-  },
-
-  {
-    "vendor": "Tuya",
-    "name": "Smart Wifi Switch 4 Gang",
-    "chip": "BK7231N",
-    "board": "CB3S",
-    "pins": {
-      "24": "Button;1",
-      "20": "Button;2",
-      "7": "Button;3",
-      "14": "Button;4",
-      "6": "Relay;1",
-      "8": "Relay;2",
-      "9": "Relay;3",
-      "26": "Relay;4",
-      "22": "WifiLED_n;1"
-    }
-  },
-
-  {
-    "vendor": "LSC",
-    "name": "Smart Connect Plug",
-    "chip": "BK7231N",
-    "board": "CB2S",
-    "pins": {
-      "6": "LED;1",
-      "7": "Button;1",
-      "26": "Relay;1"
-    }
-  },
-
-  {
-    "vendor": "DS-102",
-    "name": "1 Gang Switch",
-    "chip": "BK7231T",
-    "board": "WB3S",
-    "pins": {
-      "1": "WifiLED;1",
-      "6": "Relay;1",
-      "10": "Button;1",
-      "26": "LED;1"
-    }
-  },
-
-  {
-    "vendor": "Gosund",
-    "name": "Smart Switch",
-    "model": "SW5-A-V2.1",
-    "chip": "BK7231T",
-    "pins": {
-      "7": "WifiLED;1",
-      "14": "Relay;1",
-      "8": "Button;1",
-      "16": "LED_n;1"
-    },
-    "urls": [
-      "https://www.elektroda.com/rtvforum/viewtopic.php?p=20008969#20008969"
-    ]
-  },
-
-  {
-    "vendor": "DS-102",
-    "name": "2 Gang Switch",
-    "chip": "BK7231T",
-    "board": "WB3S",
-    "pins": {
-      "1": "WifiLED;1",
-      "6": "Relay;1",
-      "10": "Button;1",
-      "26": "LED;1",
-      "8": "Button;2",
-      "9": "Relay;2",
-      "11": "LED;2"
-    }
-  },
-
-  {
-    "vendor": "DS-102",
-    "name": "3 Gang Switch",
-    "chip": "BK7231T",
-    "board": "WB3S",
-    "pins": {
-      "1": "WifiLED;1",
-      "6": "Relay;1",
-      "24": "Button;1",
-      "14": "LED;1",
-      "9": "Relay;2",
-      "10": "Button;2",
-      "26": "LED;2",
-      "7": "Relay;3",
-      "8": "Button;3",
-      "11": "LED;3"
-    }
-  },
-
-  {
-    "vendor": "AliExpress",
-    "name": "Socket 13A",
-    "chip": "BK7231N",
-    "board": "CB2S",
-    "pins": {
-      "6": "LED;0",
-      "7": "LED;1",
-      "8": "Button;0;1",
-      "24": "Relay_n;0",
-      "25": "Relay_n;1"
-    },
-    "urls": [
-      "https://obrazki.elektroda.pl/8563462300_1652196315.jpg",
-      "https://obrazki.elektroda.pl/8998188300_1652196330.jpg",
-      "https://obrazki.elektroda.pl/2281136200_1652196339.jpg",
-      "https://obrazki.elektroda.pl/1568452900_1652196348.jpg",
-      "https://obrazki.elektroda.pl/4600787700_1652196323.jpg"
-    ]
-  },
-
-  {
-    "vendor": "Deta",
-    "name": "Smart Double Power Point Series 2",
-    "model": "6922HA",
-    "chip": "BK7231T",
-    "pins": {
-      "6": "Relay;1",
-      "9": "WifiLED_n;1",
-      "14": "Button;1",
-      "24": "Button;2",
-      "26": "Relay;2"
-    },
-    "urls": ["https://obrazki.elektroda.pl/2789424600_1656890909.jpg"]
-  }
-]
+  ]
+}

--- a/devices.json
+++ b/devices.json
@@ -469,7 +469,7 @@
       "pins": {
         "7": "LED_n;1",
         "24": "Relay;1",
-        "26": "Btn;1"
+        "26": "Button;1"
       },
       "image": "https://obrazki.elektroda.pl/1036592500_1659877616.jpg",
       "wiki": "https://www.elektroda.com/rtvforum/topic3911041.html#20133554",
@@ -483,8 +483,8 @@
       "chip": "BL602",
       "pins": {
         "1": "WifiLED_n;1",
-        "5": "Btn;1",
-        "22": "relay;1"
+        "5": "Button;1",
+        "22": "Relay;1"
       },
       "image": "https://static.elektroda.pl/attach/thumb/3_1141202.jpg",
       "wiki": "https://www.elektroda.com/rtvforum/topic3889041-120.html#20129282",
@@ -497,9 +497,9 @@
       "chip": "BK7231N",
       "pins": {
         "6": "LED_n;1",
-        "8": "Btn;1",
-        "14": "Btn;1",
-        "15": "relay;1"
+        "8": "Button;1",
+        "14": "Button;1",
+        "15": "Relay;1"
       },
       "image": "https://obrazki.elektroda.pl/6209806600_1660573904.jpg",
       "wiki": "https://www.elektroda.com/rtvforum/topic3912748.html#20145042"

--- a/devices.json
+++ b/devices.json
@@ -1,0 +1,401 @@
+[
+    {
+      "name": ""
+    },
+  
+    {
+      "name": "WiFi DIY Switch ZN268131",
+      "chip": "BK7231T",
+      "board": "WB2S",
+      "pins": {
+        "6": "Relay;1",
+        "7": "WifiLED_n;1",
+        "10": "Button;1",
+        "26": "TglChanOnTgl;1"
+      }
+    },
+  
+    {
+      "name": "Magic Home LED RGB IR Strip",
+      "chip": "BL602",
+      "pins": {
+        "4": "PWM;0",
+        "3": "PWM;1",
+        "21": "PWM;2"
+      },
+      "urls": ["https://www.elektroda.pl/rtvforum/topic3881416.html"]
+    },
+  
+    {
+      "name": "Tuya SmartSwitch SW01 16A",
+      "chip": "BK7231T",
+      "pins": {
+        "7": "Relay;1",
+        "26": "Button;1"
+      },
+      "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
+    },
+  
+    {
+      "name": "Tuya SmartLife 4CH 10A",
+      "chip": "BK7231T",
+      "pins": {
+        "7": "Button;1",
+        "8": "Button;2",
+        "9": "Button;3",
+        "1": "Button;4",
+        "14": "Relay;1",
+        "6": "Relay;2",
+        "24": "Relay;3",
+        "26": "Relay;4"
+      },
+      "urls": ["https://www.elektroda.pl/rtvforum/topic3822484.html"]
+    },
+  
+    {
+      "name": "uya E27 LED RGBCW 5PWMs",
+      "chip": "BK7231N",
+      "pins": {
+        "26": "PWM;1",
+        "8": "PWM;2",
+        "7": "PWM;3",
+        "9": "PWM;4",
+        "6": "PWM;5"
+      },
+      "urls": [
+        "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3880540&highlight="
+      ]
+    },
+  
+    {
+      "name": "IntelligentLife NF101A",
+      "chip": "BK7231T",
+      "pins": {
+        "24": "Relay;1",
+        "6": "Button;1"
+      },
+      "urls": [
+        "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19743751#19743751"
+      ]
+    },
+  
+    {
+      "name": "Tuya LED Dimmer Single Channel PWM",
+      "chip": "BK7231T",
+      "board": "WB3S",
+      "pins": {
+        "8": "PWM;1",
+        "1": "Button;1"
+      },
+      "urls": ["https://www.elektroda.pl/rtvforum/topic3798114.html"]
+    },
+  
+    {
+      "name": "Calex RGBWW LED Dimmer Five Channel PWM",
+      "chip": "BK7231S",
+      "pins": {
+        "7": "PWM;1",
+        "8": "PWM;2",
+        "6": "PWM;3",
+        "24": "PWM;4",
+        "26": "PWM;5"
+      }
+    },
+  
+    {
+      "name": "Calex UK power strip 900018.1 v1.0 UK",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "Relay;5",
+        "7": "Relay;2",
+        "8": "Relay;3",
+        "9": "Relay;1",
+        "26": "Relay;4",
+        "14": "Button;1",
+        "10": "LED;1",
+        "24": "LED;2"
+      }
+    },
+  
+    {
+      "name": "Arlec CCT LED Downlight ALD029CHA",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "PWM;4",
+        "24": "PWM;5"
+      },
+      "urls": [
+        "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-cct-led-downlight_p0168694"
+      ]
+    },
+  
+    {
+      "name": "Arlec RGB+CCT LED Downlight ALD092RHA",
+      "chip": "BK7231T",
+      "pins": {
+        "8": "PWM;1",
+        "7": "PWM;2",
+        "9": "PWM;3",
+        "6": "PWM;4",
+        "24": "PWM;5"
+      },
+      "urls": [
+        "https://www.bunnings.com.au/arlec-grid-connect-smart-9w-rgb-cct-led-downlight_p0168695"
+      ]
+    },
+  
+    {
+      "name": "CasaLife CCT LED Downlight SMART-AL2017-TGTS",
+      "chip": "BK7231T",
+      "pins": {
+        "7": "PWM;0",
+        "8": "PWM;1"
+      },
+      "urls": [
+        "https://www.elektroda.com/rtvforum/viewtopic.php?p=20123466#20123466"
+      ]
+    },
+  
+    {
+      "name": "Nedis WIFIPO120FWT SmartPlug 16A",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "LED;1",
+        "10": "Button;1",
+        "26": "Relay_n;1"
+      },
+      "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
+    },
+  
+    {
+      "name": "Nedis WIFIP130FWT SmartPlug 10A",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "LED;1",
+        "10": "Button;1",
+        "26": "Relay;1"
+      },
+      "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
+    },
+  
+    {
+      "name": "Emax Home EDU8774 SmartPlug 16A",
+      "chip": "BK7231T",
+      "pins": {
+        "10": "Button;1",
+        "24": "LED_n;1",
+        "26": "Relay;1"
+      },
+      "urls": ["https://www.elektroda.pl/rtvforum/topic3804553.html"]
+    },
+  
+    {
+      "name": "LSPA9 power metering plug BL0942 version",
+      "chip": "BK7231N",
+      "board": "CB2S",
+      "pins": {
+        "6": "Button;1",
+        "8": "WifiLED_n;1",
+        "26": "Relay;1"
+      },
+      "urls": [
+        "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3887748&highlight="
+      ]
+    },
+  
+    {
+      "name": "Qiachip Smart Switch",
+      "chip": "BK7231N",
+      "board": "CB2S",
+      "pins": {
+        "7": "Button;1",
+        "8": "Relay;1"
+      },
+      "urls": [
+        "https://www.elektroda.pl/rtvforum/viewtopic.php?t=3874289&highlight="
+      ]
+    },
+  
+    {
+      "name": "KS 602 Touch Switch US",
+      "chip": "BK7231N",
+      "pins": {
+        "17": "Relay;1",
+        "26": "Button;1"
+      }
+    },
+  
+    {
+      "name": "QiaChip Smart Switch",
+      "chip": "BK7231T",
+      "board": "WB2S",
+      "pins": {
+        "7": "Button;1",
+        "6": "Relay_n;1",
+        "10": "LED;1"
+      }
+    },
+  
+    {
+      "name": "Prime SmartOutlet Outdoor 2x CostcovCCWFIO232PK",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "Relay;1",
+        "7": "Relay;2",
+        "10": "LED;1",
+        "26": "LED;2",
+        "24": "Button;1"
+      },
+      "urls": [
+        "https://www.elektroda.pl/rtvforum/viewtopic.php?p=19906670#19906670",
+        "https://obrazki.elektroda.pl/6606464600_1642467157.jpg"
+      ]
+    },
+  
+    {
+      "name": "Tuya Smart PFW02-G",
+      "chip": "BK7231T",
+      "pins": {
+        "24": "Relay_n;1",
+        "26": "Button;1",
+        "7": "LED;1"
+      },
+      "urls": [
+        "https://www.tokmanni.fi/alypistorasia-home-connect-ip20-6419860720456"
+      ]
+    },
+  
+    {
+      "name": "Avatar ASL04 5v LED strip",
+      "chip": "BK7231T",
+      "pins": {
+        "24": "PWM;1",
+        "8": "PWM;2",
+        "6": "PWM;3",
+        "7": "Button;1",
+        "9": "Button;2",
+        "14": "Button;3"
+      }
+    },
+  
+    {
+      "name": "Tuya Smart Wifi Switch 4 Gang",
+      "chip": "BK7231N",
+      "board": "CB3S",
+      "pins": {
+        "24": "Button;1",
+        "20": "Button;2",
+        "7": "Button;3",
+        "14": "Button;4",
+        "6": "Relay;1",
+        "8": "Relay;2",
+        "9": "Relay;3",
+        "26": "Relay;4",
+        "22": "WifiLED_n;1"
+      }
+    },
+  
+    {
+      "name": "LSC Smart Connect Plug",
+      "chip": "BK7231N",
+      "board": "CB2S",
+      "pins": {
+        "6": "LED;1",
+        "7": "Button;1",
+        "26": "Relay;1"
+      }
+    },
+  
+    {
+      "name": "DS-102 1 Gang Switch",
+      "chip": "BK7231T",
+      "board": "WB3S",
+      "pins": {
+        "1": "WifiLED;1",
+        "6": "Relay;1",
+        "10": "Button;1",
+        "26": "LED;1"
+      }
+    },
+  
+    {
+      "name": "Gosund Smart Switch SW5-A-V2.1",
+      "chip": "BK7231T",
+      "pins": {
+        "7": "WifiLED;1",
+        "14": "Relay;1",
+        "8": "Button;1",
+        "16": "LED_n;1"
+      },
+      "urls": [
+        "https://www.elektroda.com/rtvforum/viewtopic.php?p=20008969#20008969"
+      ]
+    },
+  
+    {
+      "name": "DS-102 2 Gang Switch",
+      "chip": "BK7231T",
+      "board": "WB3S",
+      "pins": {
+        "1": "WifiLED;1",
+        "6": "Relay;1",
+        "10": "Button;1",
+        "26": "LED;1",
+        "8": "Button;2",
+        "9": "Relay;2",
+        "11": "LED;2"
+      }
+    },
+  
+    {
+      "name": "DS-102 3 Gang Switch",
+      "chip": "BK7231T",
+      "board": "WB3S",
+      "pins": {
+        "1": "WifiLED;1",
+        "6": "Relay;1",
+        "24": "Button;1",
+        "14": "LED;1",
+        "9": "Relay;2",
+        "10": "Button;2",
+        "26": "LED;2",
+        "7": "Relay;3",
+        "8": "Button;3",
+        "11": "LED;3"
+      }
+    },
+  
+    {
+      "name": "Aliexpress socket 13A",
+      "chip": "BK7231N",
+      "board": "CB2S",
+      "pins": {
+        "6": "LED;0",
+        "7": "LED;1",
+        "8": "Button;0",
+        "24": "Relay_n;0",
+        "25": "Relay_n;1"
+      },
+      "urls": [
+        "https://obrazki.elektroda.pl/8563462300_1652196315.jpg",
+        "https://obrazki.elektroda.pl/8998188300_1652196330.jpg",
+        "https://obrazki.elektroda.pl/2281136200_1652196339.jpg",
+        "https://obrazki.elektroda.pl/1568452900_1652196348.jpg",
+        "https://obrazki.elektroda.pl/4600787700_1652196323.jpg"
+      ]
+    },
+  
+    {
+      "name": "Deta Smart Double Power Point 6922HA Series 2",
+      "chip": "BK7231T",
+      "pins": {
+        "6": "Relay;1",
+        "9": "WifiLED_n;1",
+        "14": "Button;1",
+        "24": "Button;2",
+        "26": "Relay;2"
+      },
+      "urls": ["https://obrazki.elektroda.pl/2789424600_1656890909.jpg"]
+    }
+  ]
+  

--- a/devices.json
+++ b/devices.json
@@ -175,7 +175,7 @@
       },
       "image": "https://obrazki.elektroda.pl/4181235400_1659263189.jpg",
       "wiki": "https://www.elektroda.com/rtvforum/viewtopic.php?p=20123466#20123466",
-      "flag": "LED_RAWCHANNELSMODE"
+      "flag": 3
     },
 
     {
@@ -258,7 +258,7 @@
         "17": "Relay;1",
         "26": "Button;1"
       },
-      "flag": "BTN_INSTANTTOUCH",
+      "flag": 6,
       "image": "",
       "wiki": ""
     },

--- a/devices.json
+++ b/devices.json
@@ -4,7 +4,9 @@
   },
 
   {
-    "name": "WiFi DIY Switch ZN268131",
+    "vendor": "Generic",
+    "name": "WiFi DIY Switch",
+    "model": "ZN268131",
     "chip": "BK7231T",
     "board": "WB2S",
     "pins": {
@@ -16,7 +18,8 @@
   },
 
   {
-    "name": "Magic Home LED RGB IR Strip",
+    "vendor": "Magic Home",
+    "name": "LED RGB IR Strip",
     "chip": "BL602",
     "pins": {
       "4": "PWM;0",
@@ -27,7 +30,8 @@
   },
 
   {
-    "name": "Tuya SmartSwitch SW01 16A",
+    "vendor": "Tuya",
+    "name": "SmartSwitch SW01 16A",
     "chip": "BK7231T",
     "pins": {
       "7": "Relay;1",
@@ -37,7 +41,8 @@
   },
 
   {
-    "name": "Tuya SmartLife 4CH 10A",
+    "vendor": "Tuya",
+    "name": "SmartLife 4CH 10A",
     "chip": "BK7231T",
     "pins": {
       "7": "Button;1",
@@ -53,7 +58,8 @@
   },
 
   {
-    "name": "uya E27 LED RGBCW 5PWMs",
+    "vendor": "Tuya",
+    "name": "E27 LED RGBCW 5PWMs",
     "chip": "BK7231N",
     "pins": {
       "26": "PWM;1",
@@ -68,7 +74,8 @@
   },
 
   {
-    "name": "IntelligentLife NF101A",
+    "vendor": "Intelligent Life",
+    "name": "NF101A",
     "chip": "BK7231T",
     "pins": {
       "24": "Relay;1",
@@ -80,7 +87,8 @@
   },
 
   {
-    "name": "Tuya LED Dimmer Single Channel PWM",
+    "vendor": "Tuya",
+    "name": "LED Dimmer Single Channel PWM",
     "chip": "BK7231T",
     "board": "WB3S",
     "pins": {
@@ -91,7 +99,8 @@
   },
 
   {
-    "name": "Calex RGBWW LED Dimmer Five Channel PWM",
+    "vendor": "Calex",
+    "name": "RGBWW LED Dimmer Five Channel PWM",
     "chip": "BK7231S",
     "pins": {
       "7": "PWM;1",
@@ -103,7 +112,8 @@
   },
 
   {
-    "name": "Calex UK power strip 900018.1 v1.0 UK",
+    "vendor": "Calex",
+    "name": "UK power strip 900018.1 v1.0 UK",
     "chip": "BK7231T",
     "pins": {
       "6": "Relay;5",
@@ -118,7 +128,9 @@
   },
 
   {
-    "name": "Arlec CCT LED Downlight ALD029CHA",
+    "vendor": "Arlec",
+    "name": "CCT LED Downlight",
+    "model": "ALD029CHA",
     "chip": "BK7231T",
     "pins": {
       "6": "PWM;4",
@@ -130,7 +142,9 @@
   },
 
   {
-    "name": "Arlec RGB+CCT LED Downlight ALD092RHA",
+    "vendor": "Arlec",
+    "name": "RGB+CCT LED Downlight",
+    "model": "ALD092RHA",
     "chip": "BK7231T",
     "pins": {
       "8": "PWM;1",
@@ -145,7 +159,9 @@
   },
 
   {
-    "name": "CasaLife CCT LED Downlight SMART-AL2017-TGTS",
+    "vendor": "CasaLife",
+    "name": "CCT LED Downlight",
+    "model": "SMART-AL2017-TGTS",
     "chip": "BK7231T",
     "pins": {
       "7": "PWM;0",
@@ -158,7 +174,9 @@
   },
 
   {
-    "name": "Nedis WIFIPO120FWT SmartPlug 16A",
+    "vendor": "Nedis",
+    "name": "SmartPlug 16A",
+    "model": "WIFIPO120FWT",
     "chip": "BK7231T",
     "pins": {
       "6": "LED;1",
@@ -169,7 +187,9 @@
   },
 
   {
-    "name": "Nedis WIFIP130FWT SmartPlug 10A",
+    "vendor": "Nedis",
+    "name": "SmartPlug 10A",
+    "model": "WIFIP130FWT",
     "chip": "BK7231T",
     "pins": {
       "6": "LED;1",
@@ -180,7 +200,9 @@
   },
 
   {
-    "name": "Emax Home EDU8774 SmartPlug 16A",
+    "vendor": "Emax",
+    "name": "Home SmartPlug 16A",
+    "model": "EDU8774",
     "chip": "BK7231T",
     "pins": {
       "10": "Button;1",
@@ -191,7 +213,9 @@
   },
 
   {
-    "name": "LSPA9 power metering plug BL0942 version",
+    "vendor": "ELIVCO",
+    "name": "Power metering plug BL0942 version",
+    "model": "LSPA9",
     "chip": "BK7231N",
     "board": "CB2S",
     "pins": {
@@ -206,7 +230,8 @@
   },
 
   {
-    "name": "Qiachip Smart Switch",
+    "vendor": "QiaChip",
+    "name": "Smart Switch",
     "chip": "BK7231N",
     "board": "CB2S",
     "pins": {
@@ -219,7 +244,9 @@
   },
 
   {
-    "name": "KS 602 Touch Switch US",
+    "vendor": "Hidin Tech",
+    "name": "Touch Switch US",
+    "model": "KS602",
     "chip": "BK7231N",
     "pins": {
       "17": "Relay;1",
@@ -229,7 +256,8 @@
   },
 
   {
-    "name": "QiaChip Smart Switch",
+    "vendor": "QiaChip",
+    "name": "Smart Switch",
     "chip": "BK7231T",
     "board": "WB2S",
     "pins": {
@@ -240,7 +268,9 @@
   },
 
   {
-    "name": "Prime SmartOutlet Outdoor 2x CostcovCCWFIO232PK",
+    "vendor": "Prime",
+    "name": "SmartOutlet Outdoor 2x Costco",
+    "model": "CCWFIO232PK",
     "chip": "BK7231T",
     "pins": {
       "6": "Relay;1",
@@ -256,7 +286,9 @@
   },
 
   {
-    "name": "Tuya Smart PFW02-G",
+    "vendor": "Tuya",
+    "name": "Smart",
+    "model": "PFW02-G",
     "chip": "BK7231T",
     "pins": {
       "24": "Relay_n;1",
@@ -269,7 +301,9 @@
   },
 
   {
-    "name": "Avatar ASL04 5v LED strip",
+    "vendor": "Avatar",
+    "name": "5v LED strip",
+    "model": "ASL04",
     "chip": "BK7231T",
     "pins": {
       "24": "PWM;1",
@@ -282,7 +316,8 @@
   },
 
   {
-    "name": "Tuya Smart Wifi Switch 4 Gang",
+    "vendor": "Tuya",
+    "name": "Smart Wifi Switch 4 Gang",
     "chip": "BK7231N",
     "board": "CB3S",
     "pins": {
@@ -299,7 +334,8 @@
   },
 
   {
-    "name": "LSC Smart Connect Plug",
+    "vendor": "LSC",
+    "name": "Smart Connect Plug",
     "chip": "BK7231N",
     "board": "CB2S",
     "pins": {
@@ -310,7 +346,8 @@
   },
 
   {
-    "name": "DS-102 1 Gang Switch",
+    "vendor": "DS-102",
+    "name": "1 Gang Switch",
     "chip": "BK7231T",
     "board": "WB3S",
     "pins": {
@@ -322,7 +359,9 @@
   },
 
   {
-    "name": "Gosund Smart Switch SW5-A-V2.1",
+    "vendor": "Gosund",
+    "name": "Smart Switch",
+    "model": "SW5-A-V2.1",
     "chip": "BK7231T",
     "pins": {
       "7": "WifiLED;1",
@@ -336,7 +375,8 @@
   },
 
   {
-    "name": "DS-102 2 Gang Switch",
+    "vendor": "DS-102",
+    "name": "2 Gang Switch",
     "chip": "BK7231T",
     "board": "WB3S",
     "pins": {
@@ -351,7 +391,8 @@
   },
 
   {
-    "name": "DS-102 3 Gang Switch",
+    "vendor": "DS-102",
+    "name": "3 Gang Switch",
     "chip": "BK7231T",
     "board": "WB3S",
     "pins": {
@@ -369,7 +410,8 @@
   },
 
   {
-    "name": "AliExpress socket 13A",
+    "vendor": "AliExpress",
+    "name": "Socket 13A",
     "chip": "BK7231N",
     "board": "CB2S",
     "pins": {
@@ -389,7 +431,9 @@
   },
 
   {
-    "name": "Deta Smart Double Power Point 6922HA Series 2",
+    "vendor": "Deta",
+    "name": "Smart Double Power Point Series 2",
+    "model": "6922HA",
     "chip": "BK7231T",
     "pins": {
       "6": "Relay;1",

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,90 @@
+{
+  "$id": "https://github.com/openshwprojects/obj_webapp/schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "DeviceDatabase",
+  "description": "OpenBK7231T Device database",
+  "type": "object",
+  "required": ["version", "devices"],
+  "properties": {
+    "version": {
+      "description": "Database version",
+      "type": "number"
+    },
+    "devices": {
+      "description": "Devices",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/device"
+      }
+    }
+  },
+  "$defs": {
+    "device": {
+      "description": "Device definition",
+      "type": "object",
+      "required": ["vendor", "name", "chip", "pins", "wiki", "image"],
+      "properties": {
+        "vendor": {
+          "description": "Vendor",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name",
+          "type": "string"
+        },
+        "model": {
+          "description": "Model",
+          "type": "string"
+        },
+        "chip": {
+          "description": "Chip",
+          "type": "string"
+        },
+        "board": {
+          "description": "Board",
+          "type": "string"
+        },
+        "pins": {
+          "description": "Pin definitions",
+          "type": "object",
+          "minProperties": 1,
+          "patternProperties": {
+            "^[0-9]*$": {
+              "type": "string"
+            }
+          }
+        },
+        "wiki": {
+          "description": "Wiki url",
+          "type": "string"
+        },
+        "command": {
+          "description": "Additional custom command",
+          "type": "string"
+        },
+        "flag": {
+          "description": "Additional custom flag",
+          "type": "string"
+        },
+        "image": {
+          "description": "Main image url",
+          "type": "string"
+        },
+        "keywords": {
+          "description": "Search keywords",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "gallery": {
+          "description": "Gallery image urls",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -22,7 +22,7 @@
     "device": {
       "description": "Device definition",
       "type": "object",
-      "required": ["vendor", "name", "chip", "pins", "wiki", "image"],
+      "required": ["vendor", "name", "chip", "pins", "image", "wiki"],
       "properties": {
         "vendor": {
           "description": "Vendor",
@@ -54,9 +54,20 @@
             }
           }
         },
+        "image": {
+          "description": "Main image url",
+          "type": "string"
+        },
         "wiki": {
           "description": "Wiki url",
           "type": "string"
+        },
+        "urls": {
+          "description": "Additional urls",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "command": {
           "description": "Additional custom command",
@@ -66,12 +77,8 @@
           "description": "Additional custom flag",
           "type": "string"
         },
-        "image": {
-          "description": "Main image url",
-          "type": "string"
-        },
         "keywords": {
-          "description": "Search keywords",
+          "description": "Keywords",
           "type": "array",
           "items": {
             "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -79,9 +79,10 @@
           "maxLength": 127
         },
         "flag": {
-          "description": "OBK Device flag to set",
-          "type": "string",
-          "maxLength": 127
+          "description": "OBK Device flag to set (see new_pins.h)",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 10
         },
         "keywords": {
           "description": "Keywords",

--- a/schema.json
+++ b/schema.json
@@ -74,12 +74,14 @@
           }
         },
         "command": {
-          "description": "Additional custom command",
-          "type": "string"
+          "description": "Startup command",
+          "type": "string",
+          "maxLength": 127
         },
         "flag": {
-          "description": "Additional custom flag",
-          "type": "string"
+          "description": "OBK Device flag to set",
+          "type": "string",
+          "maxLength": 127
         },
         "keywords": {
           "description": "Keywords",

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/openshwprojects/obj_webapp/schema.json",
+  "$id": "https://github.com/OpenBekenIOT/webapp/schema.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "DeviceDatabase",
   "description": "OpenBK7231T Device database",
@@ -60,6 +60,10 @@
         },
         "wiki": {
           "description": "Wiki url",
+          "type": "string"
+        },
+        "product": {
+          "description": "Product url",
           "type": "string"
         },
         "urls": {

--- a/startup.js
+++ b/startup.js
@@ -20,6 +20,7 @@ window.onload = ()=>{
     appdiv.appendChild(comp);
     
     window.components = [
+        { name:'device', path: window.root+'vue/device.vue' },
         { name:'ota', path: window.root+'vue/ota.vue' },
         { name:'filesystem', path: window.root+'vue/filesystem.vue' },
         { name:'info', path: window.root+'vue/info.vue' },

--- a/vue/device.vue
+++ b/vue/device.vue
@@ -1,9 +1,9 @@
 <template>
-  <div v-if="selectedDevice">
+  <div v-if="selectedDevice" style="width:300px;">
     <div>
       Chipset: {{ selectedDevice.chip}} {{ selectedDevice.board }}<br/>
       Model: {{ selectedDevice.model || "Unknown"}}<br/>
-      <img v-if="selectedDevice.image" v-bind:src="selectedDevice.image" height="200" v-bind:alt="getDeviceDisplayName(selectedDevice)"/>
+      <img v-if="selectedDevice.image" v-bind:src="selectedDevice.image" width="250" v-bind:alt="getDeviceDisplayName(selectedDevice)"/>
     </div>
 
     <ul>
@@ -16,6 +16,13 @@
         </span>
       </li>
     </ul>
+    
+    <div v-if="selectedDevice.flag !== undefined">
+      Flag:&nbsp;<span>{{selectedDevice.flag}}
+    </div>
+    <div v-if="selectedDevice.command">
+      Command:&nbsp;<span>{{selectedDevice.command}}
+    </div>
     
     <span v-if="selectedDevice.wiki">
       <a v-bind:href="selectedDevice.wiki" target="_blank">Forum</a>&nbsp;

--- a/vue/device.vue
+++ b/vue/device.vue
@@ -1,0 +1,44 @@
+<template>
+  <div v-if="selectedDevice">
+    <div>
+      Chipset: {{ selectedDevice.chip}} {{ selectedDevice.board }}<br/>
+      Model: {{ selectedDevice.model || "unknown"}}<br/>
+      <img v-bind:src="selectedDevice.image" height="200" v-bind:alt="getDeviceDisplayName(selectedDevice)"/>
+    </div>
+
+    <ul>
+      <li v-for="(pin,key) in selectedDevice.pins" :key="key">
+        <span v-if="pin.split(';').length === 2">
+          Pin {{key}}: {{ pin.split(';')[0] }} on channel {{ pin.split(';')[1] }} {{ pin.split(';')[2] }}
+        </span>
+        <span v-else>
+          Pin {{key}}: {{ pin.split(';')[0] }} on channels {{ pin.split(';')[1] }}, {{ pin.split(';')[2] }}
+        </span>
+      </li>
+    </ul>
+
+    <a v-bind:href="selectedDevice.wiki" target="_blank">Wiki</a>
+    <div v-if="selectedDevice.urls">
+      Links: 
+      <span v-for="(url,index) in selectedDevice.urls" :key="url">
+        <span v-if="index > 0">, </span><a v-bind:href="url" target="_blank">{{index+1}}</a>
+      </span>
+      <br/>
+    </div>
+  </div>
+</template>
+
+<script>
+  module.exports = {
+    props: {
+      selectedDevice: Object
+    },
+    methods:{
+      getDeviceDisplayName(dev){
+        //The first option is placeholder with no name
+        return dev.name ? dev.vendor + " " + dev.name : "";
+      }
+    }
+}
+//@ sourceURL=/vue/device.vue
+</script>

--- a/vue/device.vue
+++ b/vue/device.vue
@@ -2,8 +2,8 @@
   <div v-if="selectedDevice">
     <div>
       Chipset: {{ selectedDevice.chip}} {{ selectedDevice.board }}<br/>
-      Model: {{ selectedDevice.model || "unknown"}}<br/>
-      <img v-bind:src="selectedDevice.image" height="200" v-bind:alt="getDeviceDisplayName(selectedDevice)"/>
+      Model: {{ selectedDevice.model || "Unknown"}}<br/>
+      <img v-if="selectedDevice.image" v-bind:src="selectedDevice.image" height="200" v-bind:alt="getDeviceDisplayName(selectedDevice)"/>
     </div>
 
     <ul>
@@ -16,8 +16,14 @@
         </span>
       </li>
     </ul>
+    
+    <span v-if="selectedDevice.wiki">
+      <a v-bind:href="selectedDevice.wiki" target="_blank">Forum</a>&nbsp;
+    </span>
+    <span v-if="selectedDevice.product">
+      <a v-bind:href="selectedDevice.product" target="_blank">Product</a>&nbsp;
+    </span>
 
-    <a v-bind:href="selectedDevice.wiki" target="_blank">Wiki</a>
     <div v-if="selectedDevice.urls">
       Links: 
       <span v-for="(url,index) in selectedDevice.urls" :key="url">
@@ -35,8 +41,8 @@
     },
     methods:{
       getDeviceDisplayName(dev){
-        //The first option is placeholder with no name
-        return dev.name ? dev.vendor + " " + dev.name : "";
+        //The first option is a placeholder with null value
+        return dev ? dev.vendor + " " + dev.name : "";
       }
     }
 }

--- a/vue/info.vue
+++ b/vue/info.vue
@@ -26,12 +26,14 @@
               <br/><br/>
 
               <select v-model="selectedDevIndex">
-                <option v-for="(dev, index) in filteredDevices" :value="index" :key="index">{{dev.name}}</option>
+                <option v-for="(dev, index) in filteredDevices" :value="index" :key="index">{{ getDeviceDisplayName(dev) }}</option>
               </select>
               
               <div v-if="selectedDevIndex > 0">
                 <br/>
                 Chipset: {{ devices[selectedDevIndex].chip}} {{ devices[selectedDevIndex].board }}
+                <br/>
+                Model: {{ devices[selectedDevIndex].model }}
 
                 <ul>
                   <li v-for="(pin,key) in devices[selectedDevIndex].pins" :key="key">
@@ -244,8 +246,8 @@
           .then(response => response.json())
           .then(data => {
             this.devices = data.sort((a,b) => {
-              const nameA = a.name.toLowerCase();
-              const nameB = b.name.toLowerCase();
+              const nameA = this.getDeviceDisplayName(a).toLowerCase();
+              const nameB = this.getDeviceDisplayName(b).toLowerCase();
               return nameA < nameB ? -1 : (nameA > nameB ? 1: 0);
             });
           })
@@ -253,6 +255,9 @@
               this.error = err.toString();
               console.error(err)
             });
+      },
+      getDeviceDisplayName(dev){
+        return dev.vendor + " " + dev.name;
       }
     },
     mounted (){

--- a/vue/info.vue
+++ b/vue/info.vue
@@ -13,7 +13,7 @@
       <p v-if="error">Error: {{error}}</p>
     </div>
 
-    <div class="item" v-if="supportsClientDeviceDB">
+    <div class="item" v-if="supportsClientDeviceDB" style="width: 300px;">
       <h4>Devices:</h4>
       Chipset:
       <select v-model="selectedChipset">
@@ -22,7 +22,7 @@
       {{ (filteredDevices || []).length - 1 }} devices
       <br/><br/>
 
-      <select v-model="selectedDevice" >
+      <select v-model="selectedDevice" style="width: 250px;">
         <option v-for="dev in filteredDevices" :value="dev" :key="dev">{{ getDeviceDisplayName(dev) }}</option>
       </select>
 
@@ -47,7 +47,7 @@
 
       <br/>
       <label for="deviceFlag" style="width:75px; display: inline-block;">Flag:</label>&nbsp;<input id="deviceFlag" v-model="deviceFlag" /><br/>
-      <label for="deviceCommand" style="width:75px; display: inline-block;">Command:</label>&nbsp;<input id="deviceCommand" v-model="deviceCommand" /><br/>
+      <label for="deviceCommand" style="width:75px; display: inline-block;">Command:</label>&nbsp;<input id="deviceCommand" v-model="deviceCommand" placeholder="Startup command"/><br/>
       
       <button @click="savePins">Save Pins</button>
     </div>
@@ -279,6 +279,6 @@
   }
 
   .item {
-    padding: 0 15px;
+    padding: 0 10px 0 10px;
   }
 </style>

--- a/vue/info.vue
+++ b/vue/info.vue
@@ -52,8 +52,9 @@
                   <br/><br/>
                 </div>
 
-                <button @click="useDevice">Use device</button>
+                <button @click="useDevice">Copy Device Pins</button>
               </div>
+              <div v-else>Pick a device from the dropdown.</div>
               
             </td>
             <td style="vertical-align:top; padding-left:5px;">

--- a/vue/info.vue
+++ b/vue/info.vue
@@ -11,16 +11,51 @@
         <p>Chipset: {{chipset}}</p>
         <p v-if="error">Error: {{error}}</p>
       </div>
+
       <div class="right">
-        <p>Pin Settings:</p>
-        <div v-for="(role, index) in pins.roles" :key="index">
-          <span>{{index}}</span>
-          <select v-model="pins.roles[index]">
-            <option v-for="(name, index2) in pins.rolenames" :value="index2" :key="index2" :selected="(role == index2)">{{name}}</option>
-          </select>
-          <input type="number" min="0" max="32" step="1" v-model="pins.channels[index]">
-        </div>
-        <button @click="savePins">Save Pins</button>
+        <table width="100%">
+          <tr>
+            <td style="vertical-align:top; padding-right:5px; width: 250px;">
+              <p>Devices:</p>
+
+              <select v-model="selectedDevIndex">
+                <option v-for="(dev, index) in devices" :value="index" :key="index">{{dev.name}}</option>
+              </select>
+
+              <div v-if="selectedDevIndex>0">
+                {{ devices[selectedDevIndex].chip}} {{ devices[selectedDevIndex].board }}
+
+                <div v-if="devices[selectedDevIndex].urls">
+                  More Info: 
+                  <span v-for="(url,index) in devices[selectedDevIndex].urls" :key="url">
+                    <a v-bind:href="url" target="_blank">{{index+1}}</a>
+                  </span>
+                </div>
+
+                <ul>
+                  <li v-for="(pin,key) in devices[selectedDevIndex].pins" :key="key">
+                  Pin {{key}} as {{ pin.split(';')[0] }} on channel {{ pin.split(';')[1] }}
+                  </li>
+                </ul>
+                <button @click="useDevice">Use device</button>
+              </div>
+              
+            </td>
+            <td style="vertical-align:top; padding-left:5px;">
+
+              <p>Pin Settings:</p>
+              <div v-for="(role, index) in pins.roles" :key="index">
+                <span>{{index}}</span>
+                <select v-model="pins.roles[index]">
+                  <option v-for="(name, index2) in pins.rolenames" :value="index2" :key="index2" :selected="(role == index2)">{{name}}</option>
+                </select>
+                <input type="number" min="0" max="32" step="1" v-model="pins.channels[index]">
+              </div>
+              <button @click="savePins">Save Pins</button>
+              
+            </td>
+          </tr>
+        </table>
       </div>
     </div>
 </template>
@@ -43,9 +78,39 @@
 
         error:'',
         interval: null,
+
+        devices: null,
+        selectedDevIndex: 0,
+        pinRoleNames: [
+          " ",
+          "Relay",
+          "Relay_n",
+          "Button",
+          "Button_n",
+          "LED",
+          "LED_n",
+          "PWM",
+          "WifiLED",
+          "WifiLED_n",
+          "Btn_Tgl_All",
+          "Btn_Tgl_All_n",
+          "dInput",
+          "dInput_n",
+          "TglChanOnTgl",
+          "dInput_NoPullUp",
+          "dInput_NoPullUp_n",
+          "BL0937SEL",
+          "BL0937CF",
+          "BL0937CF1",
+          "ADC",
+          "SM2135DAT",
+          "SM2135CLK"
+        ]
       }
     },
     methods:{
+      onDeviceSelected(event){
+      },
       getinfo(){
         let url = window.device+'/api/info';
         fetch(url)
@@ -106,6 +171,47 @@
             }); // Never forget the final catch!
 
         console.log('would save',this.pins);
+      },
+      getRoleIndex(role){
+        return this.pinRoleNames.indexOf(role);
+      },
+      useDevice(){
+        if (this.selectedDevIndex===0){ //Nothing was selected, first item is empty
+          return;
+        }
+
+        var newPinsRoles = [];
+        var newPinsChannels = [];
+        for (let i = 0; i < this.pins.roles.length; i++){
+          newPinsRoles.push(0);
+          newPinsChannels.push(0);
+        }
+
+        var devicePins = this.devices[this.selectedDevIndex].pins;
+        for(let pin in devicePins){
+          let roleChannel = devicePins[pin].split(";");
+
+          newPinsRoles[pin]=this.getRoleIndex(roleChannel[0].trim());
+          newPinsChannels[pin] = roleChannel[1].trim();
+        }
+
+        this.pins.roles = newPinsRoles;
+        this.pins.channels = newPinsChannels;
+      },
+      getDevices(){
+        fetch("devices.json")
+          .then(response => response.json())
+          .then(data => {
+            this.devices = data.sort((a,b) => {
+              const nameA = a.name.toLowerCase();
+              const nameB = b.name.toLowerCase();
+              return nameA < nameB ? -1 : (nameA > nameB ? 1: 0);
+            });
+          })
+          .catch(err => {
+              this.error = err.toString();
+              console.error(err)
+            });
       }
     },
     mounted (){
@@ -113,6 +219,7 @@
         console.log('mounted controller');
         this.getPins();
         this.getinfo();
+        this.getDevices();
         this.interval = setInterval(()=>{
           this.getinfo();
         }, 10000);

--- a/vue/info.vue
+++ b/vue/info.vue
@@ -159,21 +159,34 @@
 
       },
       savePins() {
+        let tosave = {};
+
+        //Send more data pieces conditionally to prevent errors
+        if (this.supportsClientDeviceDB) { 
+          //Valid deviceFlag is >=0 and <=10 (see new_pins.h)
+          var deviceFlagParsed = parseInt(this.deviceFlag, 10);
+          if (!isFinite(deviceFlagParsed) || isNaN(deviceFlagParsed) || (deviceFlagParsed < 0) || (deviceFlagParsed > 10)){
+            alert("Invalid flag value. Valid values are integers >= 0 and <= 10");
+            return;
+          }
+          
+          tosave.deviceFlag = deviceFlagParsed;
+
+          //Only send non-empty string value
+          var deviceCommandParsed = (this.deviceCommand || "").trim();
+          if (deviceCommandParsed){
+            tosave.deviceCommand = deviceCommandParsed;
+          }
+        }
+
         for (let i = 0; i < this.pins.channels.length; i++){
           this.pins.channels[i] = +this.pins.channels[i];
         }
         for (let i = 0; i < this.pins.roles.length; i++){
           this.pins.roles[i] = +this.pins.roles[i];
         }
-        let tosave = {
-          channels: this.pins.channels,
-          roles: this.pins.roles
-        }
-
-        if (this.supportsClientDeviceDB) { //Send more data pieces conditionally to prevent errors
-          tosave.deviceFlag = this.deviceFlag;
-          tosave.deviceCommand = this.deviceCommand;
-        }
+        tosave.channels = this.pins.channels;
+        tosave.roles = this.pins.roles;
 
         let url = window.device+'/api/pins';
         fetch(url, {

--- a/vue/info.vue
+++ b/vue/info.vue
@@ -29,7 +29,7 @@
       <div>
         <device :selected-device="selectedDevice" style="margin: 10px 0"></device>
         <div v-if="selectedDevice">
-          <button @click="useDevice">Copy Device Pins</button>
+          <button @click="useDevice">Copy Device Settings</button>
         </div>
         <div v-else>Pick a device from the dropdown.</div>
       </div>
@@ -44,6 +44,11 @@
         </select>
         <input type="number" min="0" max="32" step="1" v-model="pins.channels[index]">
       </div>
+
+      <br/>
+      <label for="deviceFlag" style="width:75px; display: inline-block;">Flag:</label>&nbsp;<input id="deviceFlag" v-model="deviceFlag" /><br/>
+      <label for="deviceCommand" style="width:75px; display: inline-block;">Command:</label>&nbsp;<input id="deviceCommand" v-model="deviceCommand" /><br/>
+      
       <button @click="savePins">Save Pins</button>
     </div>
   </div>


### PR DESCRIPTION
@btsimonh, @openshwprojects
Issue: [!145](https://github.com/openshwprojects/OpenBK7231T_App/issues/145)

The client device database lives in `devices.json` and has a validation schema `schema.json`. I curated the data from `new_builtin_devices.cs` and forum posts. I did my best to accommodate fields based on the current data. It can be easily extended to include more images, etc. 

I will note that many forum posts are linking to images elsewhere but I did not note any permissions for such linkage. These external images could easily change. It would be best if the images were in the forum or some static wiki.

The available devices appear in the middle of Config tag if the device being configured has the firmware supporting this.
![image](https://user-images.githubusercontent.com/6459774/185800515-a6f1e8be-4069-4dab-9bc4-02935b8adcf5.png)
 The UI comes from a new Vue component and allows filtering by chipset and display details.
![image](https://user-images.githubusercontent.com/6459774/185800564-3cfe5226-633c-41ab-8246-e81a097e4ff1.png)
![image](https://user-images.githubusercontent.com/6459774/185800579-d84a21bf-0ca1-4acd-893e-1c0bc1a42fbd.png)

One would click `Copy Device Pins` to apply the settings to `Pin Settings` and then continue with `Save Pins` as before. All this could be improved separately.

Flag validation:
![image](https://user-images.githubusercontent.com/6459774/186304433-6fb92c6f-da98-49ed-8131-99d8233ec184.png)
