### PR TITLE
Check flag only if populated

### DIFF
--- a/vue/control.vue
+++ b/vue/control.vue
@@ -9,7 +9,7 @@
                 v-bind:key="'button'+item" 
                 :class="item?'set':'unset'" 
                 @click="channelclick(key)"
-              >{{channels[key]?'Off':'On'}}</button>
+              >{{channels[key]?'On':'Off'}}</button>
               <span v-bind:key="'span'+item">{{key}}:{{item}} role {{outputchannelrolenames[+key]}}{{channeltag[+key]}}</span>
               <input 
                 v-if="outputchannelrolenames[+key] === 'PWM'" 

--- a/vue/info.vue
+++ b/vue/info.vue
@@ -164,10 +164,12 @@
         //Send more data pieces conditionally to prevent errors
         if (this.supportsClientDeviceDB) { 
           //Valid deviceFlag is >=0 and <=10 (see new_pins.h)
-          var deviceFlagParsed = parseInt(this.deviceFlag, 10);
-          if (!isFinite(deviceFlagParsed) || isNaN(deviceFlagParsed) || (deviceFlagParsed < 0) || (deviceFlagParsed > 10)){
-            alert("Invalid flag value. Valid values are integers >= 0 and <= 10");
-            return;
+          if (this.deviceFlag){ //Check flag value if populated
+            var deviceFlagParsed = parseInt(this.deviceFlag, 10);
+            if (!isFinite(deviceFlagParsed) || isNaN(deviceFlagParsed) || (deviceFlagParsed < 0) || (deviceFlagParsed > 10)){
+              alert("Invalid flag value. Valid values are integers >= 0 and <= 10");
+              return;
+            }
           }
           
           tosave.deviceFlag = deviceFlagParsed;


### PR DESCRIPTION
Fixed `Invalid flag value. Valid values are integers >= 0 and <= 10` error message appearing for empty flag value.