### PR TITLE
When fetching log entries, leave last \n in place

### DIFF
--- a/vue/logs.vue
+++ b/vue/logs.vue
@@ -143,7 +143,7 @@
                     this.logs += data;
                     let splt = this.logs.split('\n');
                     // remove empty
-                    for (let i = splt.length-1; i >= 0; i--) {
+                    for (let i = splt.length-2; i >= 0; i--) {
                         if (!splt[i]){
                             splt.splice(i, 1);
                         }


### PR DESCRIPTION
This matches the serial & TCP:9000 logs, as well as the batched logs that are initially fetched. 

Test version with these changes hosted at https://tabby-polar-flight.glitch.me/

(Removing the extra \n's while logging in OpenBK makes the log output in the webapp look like it's missing an \n, but it's just an off-by-one bug)

Attached screenshot of logging tab with this change
![Screenshot from 2022-10-08 13-27-34](https://user-images.githubusercontent.com/3252261/194705205-4ac1b591-2921-41e4-8177-53afc4d5b095.png)
