### PR TITLE
Styling improvements

### DIFF
--- a/startup.js
+++ b/startup.js
@@ -9,6 +9,13 @@ s1 = document.createElement('script');
 s1.setAttribute('src', window.root+"lib/httpVueLoader.js");
 document.head.appendChild(s1);
 
+//Root styles - prevent scrollbar in body, consistent default font
+var css = document.createElement("style");
+css.type = "text/css";
+var styles = "body{margin:0; padding:0;} *{font-family: 'Segoe UI',Arial,sans-serif;}";
+css.appendChild(document.createTextNode(styles));
+document.head.appendChild(css);
+
 window.onload = ()=>{
     
     var appdiv = document.createElement('div');

--- a/vue/filesystem.vue
+++ b/vue/filesystem.vue
@@ -349,5 +349,6 @@
     }
     .bottom {
         height:90%;
+        position: relative;
     }
 </style>

--- a/vue/flash.vue
+++ b/vue/flash.vue
@@ -4,7 +4,7 @@
         <button @click="rf(null, $event)">Read RF Config</button>
         <button @click="config(null, $event)">Read Config</button>
         </div>
-        <div v-html="display"></div>
+        <div v-html="display" class="display"></div>
     </div>
 </template>
 
@@ -81,4 +81,8 @@
 </script>
 
 <style scoped>
+.display pre{
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 14px;
+}
 </style>

--- a/vue/info.vue
+++ b/vue/info.vue
@@ -38,7 +38,7 @@
     <div class="item">
       <h4>Pin Settings:</h4>
       <div v-for="(role, index) in pins.roles" :key="index">
-        <span>{{index}}</span>
+        <span class="pin-index">{{index}}</span>
         <select v-model="pins.roles[index]">
           <option v-for="(name, index2) in pins.rolenames" :value="index2" :key="index2" :selected="(role == index2)">{{name}}</option>
         </select>
@@ -286,6 +286,10 @@
   }
 
   .item {
-    padding: 0 10px 0 10px;
+    padding: 0 15px;
+  }
+  .pin-index {
+    display: inline-block;
+    width: 20px;
   }
 </style>

--- a/vue/logs.vue
+++ b/vue/logs.vue
@@ -17,9 +17,10 @@
                     <label>Log Features:</label>
                 </td>
                 <td>
-                    <label class="feature" :for="item" v-for="(item, index) in logfeaturenames" :key="item">{{item}}
+                    <div class="feature" v-for="(item, index) in logfeaturenames" :key="item">
                         <input class="checkbox" type="checkbox" :id="item" :name="item" v-model="logfeatures[index]" @click="setfeature(index, $event)">
-                    </label>
+                        <label :for="item">{{item}}</label>
+                    </div>
                 </td>
             </tr>
             <tr>
@@ -54,24 +55,22 @@
         logs: '',
         cmd: '',
         paused:false,
-        logfeaturenames:[
-            "HTTP:",//            = 0,
-            "MQTT:",//            = 1,
-            "CFG:",//             = 2,
-            "HTTP_CLIENT:",//     = 3,
-            "OTA:",//             = 4,
-            "PINS:",//            = 5,
-            "MAIN:",//            = 6,
-            "GEN:", //              = 7
-            "API:", // = 8
-            "LFS:", // = 9
-            "CMD:", // = 10
-        ],
-        logfeatures:[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
-
+        logfeaturenames:[],
+            // "HTTP",//            = 0,
+            // "MQTT",//            = 1,
+            // "CFG",//             = 2,
+            // "HTTP_CLIENT",//     = 3,
+            // "OTA",//             = 4,
+            // "PINS",//            = 5,
+            // "MAIN",//            = 6,
+            // "GEN", //              = 7
+            // "API", // = 8
+            // "LFS", // = 9
+            // "CMD", // = 10
+        
+        logfeatures:[],
         loglevel:6,
-        loglevelnames:[
-        ],
+        loglevelnames:[],
         initialised: false,
       }
     },
@@ -87,7 +86,7 @@
             .then(response => response.json())
             .then(data => {
                 console.log('logconfig',data);
-                this.logfeaturenames = data.featurenames;
+                this.logfeaturenames = data.featurenames.map(x => x.split(':')[0]);
                 this.loglevelnames = data.levelnames;
                 for (let i = 0; i < 31; i++){
                     if ((data.features >> i) & 1){
@@ -225,7 +224,8 @@
     bottom: 0;
 }
 .feature {
-    margin-right:2em
+    margin-right:2em;
+    display: inline-block;
 }
 
 .checkbox {

--- a/vue/logs.vue
+++ b/vue/logs.vue
@@ -17,9 +17,9 @@
                     <label>Log Features:</label>
                 </td>
                 <td>
-                    <div class="feature" v-for="(item, index) in logfeaturenames" :key="item">
-                        <input class="checkbox" type="checkbox" :id="item" :name="item" v-model="logfeatures[index]" @click="setfeature(index, $event)">
-                        <label :for="item">{{item}}</label>
+                    <div class="feature" v-for="(item) in sortedLogFeatureNames" :key="item">
+                        <input class="checkbox" type="checkbox" :id="item.title" :name="item.title" v-model="logfeatures[item.index]" @click="setfeature(item.index, $event)">
+                        <label :for="item.title">{{item.title}}</label>
                     </div>
                 </td>
             </tr>
@@ -55,7 +55,7 @@
         logs: '',
         cmd: '',
         paused:false,
-        logfeaturenames:[],
+        sortedLogFeatureNames:[],
             // "HTTP",//            = 0,
             // "MQTT",//            = 1,
             // "CFG",//             = 2,
@@ -71,7 +71,7 @@
         logfeatures:[],
         loglevel:6,
         loglevelnames:[],
-        initialised: false,
+        initialised: false
       }
     },
     watch:{
@@ -86,7 +86,15 @@
             .then(response => response.json())
             .then(data => {
                 console.log('logconfig',data);
-                this.logfeaturenames = data.featurenames.map(x => x.split(':')[0]);
+
+                this.sortedLogFeatureNames = data.featurenames.map(function(x, index){
+                    var title = x;
+                    if (title.endsWith(":")){
+                        title = title.substr(0, title.length-1);
+                    }
+                    return {title: title, index: index};
+                }).sort((a,b) => a.title.localeCompare(b.title));
+
                 this.loglevelnames = data.levelnames;
                 for (let i = 0; i < 31; i++){
                     if ((data.features >> i) & 1){

--- a/vue/logs.vue
+++ b/vue/logs.vue
@@ -1,31 +1,49 @@
 <template>
-    <div class="fullheight">
-      <div ref="logs" style="height:80%; overflow:scroll;" id="logs"><pre>{{logs}}</pre></div>
+    <div class="container">
+        <textarea readonly ref="logs" style="overflow:scroll;" id="logs" class="logs">{{logs}}</textarea>
 
-      <label for="pause">Pause<input  class="checkbox" type="checkbox" id="pause" name="pause" v-model="paused"></label>
-      
-      <button class="feature" @click="clear">Clear</button>
-      <br />
-
-      <label>Log Features:
-        <label class="feature" :for="item" v-for="(item, index) in logfeaturenames" :key="item">{{item}}
-            <input class="checkbox" type="checkbox" :id="item" :name="item" v-model="logfeatures[index]" @click="setfeature(index, $event)">
-        </label>
-      </label>
-      <br />
-      <label>Log Level:
-        <select v-model="loglevel">
-            <option v-for="(item,index) of loglevelnames" :value="index" :key="index">{{item}}</option>
-        </select>
-      </label>
-
-      <form @submit="send($event)">
-        <label>Cmd:
-          <input v-model="cmd" id="obkcommand" type="text" autocomplete="on" style="width:60%;">
-        </label>
-
-        <input type="submit">
-      </form>
+        <table class="logging-settings">
+            <tr>
+                <td style="width: 80px">
+                    Logging:
+                </td>
+                <td>
+                    <button class="logging" :class="{paused:paused}"  @click="paused = !paused">{{paused?"Resume":"Pause"}}</button>
+                    <button class="feature" @click="clear">Clear</button>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 80px">
+                    <label>Log Features:</label>
+                </td>
+                <td>
+                    <label class="feature" :for="item" v-for="(item, index) in logfeaturenames" :key="item">{{item}}
+                        <input class="checkbox" type="checkbox" :id="item" :name="item" v-model="logfeatures[index]" @click="setfeature(index, $event)">
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 80px">
+                    <label>Log Level:</label>
+                </td>
+                <td>
+                    <select v-model="loglevel">
+                        <option v-for="(item,index) of loglevelnames" :value="index" :key="index">{{item}}</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label>Command:</label>
+                </td>
+                <td>
+                    <form @submit="send($event)">
+                        <input v-model="cmd" id="obkcommand" type="text" autocomplete="on" style="width:60%;">
+                        <input type="submit">
+                    </form>
+                </td>
+            </tr>
+        </table>
     </div>
 </template>
 
@@ -190,16 +208,35 @@
 </script>
 
 <style scoped>
-.fullheight {
-    height:95%;
+.container .logs{
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 150px;
+    left: 0;
+    margin: 0 10px;
+    font-family: 'Courier New', Courier, monospace;
+    resize: none;
 }
-
+.container .logging-settings{
+    height: 150px;
+    overflow: auto;
+    position: absolute;
+    bottom: 0;
+}
 .feature {
-    margin-left:2em
+    margin-right:2em
 }
 
 .checkbox {
     vertical-align: bottom;
 }
 
+button.logging.paused{
+   background-color: #c0c0c0;
+}
+
+button.feature, button.logging{
+    width: 75px;
+}
 </style>

--- a/vue/myComponent.vue
+++ b/vue/myComponent.vue
@@ -25,7 +25,7 @@
     <div class="tabcontent" v-if="tab === 'Status'">
       <h3>Status</h3>
       <control-controller></control-controller>
-    </div>    
+    </div>
 
     <div class="tabcontent" v-if="tab === 'About'">
       <h3>About</h3>
@@ -33,20 +33,20 @@
       <p>A simple web app to go with OpenBekenIOT equipped devices by <a href="https://github.com/btsimonh">btsimonh</a></p>
       <p>This app is a pure javascript application written in VueJS as an SFC .vue component, and dynamically loaded from the device via a simple webpage.  The intent here is to be able to provide a rich UI and allow the device UI to remain simple (and small).</p>
       <p>Currently, it supports displaying logging from the device</p>
-    </div>    
+    </div>
 
     <div class="tabcontent" v-if="tab === 'OTA'">
       <h3>OTA</h3>
       <ota-controller></ota-controller>
-    </div>    
+    </div>
     <div class="tabcontent" v-if="tab === 'Flash'">
       <h3>Flash</h3>
       <flash-controller></flash-controller>
-    </div>    
+    </div>
     <div class="tabcontent" v-if="tab === 'Filesystem'">
       <h3>Filesystem</h3>
       <filesystem-controller></filesystem-controller>
-    </div>    
+    </div>
 
     </div>
 </template>
@@ -117,6 +117,8 @@
       overflow: hidden;
       border: 1px solid #ccc;
       background-color: #f1f1f1;
+      height: 40px;
+      box-sizing: border-box;
     }
     
     /* Style the buttons that are used to open the tab content */
@@ -142,16 +144,29 @@
     
     /* Style the tab content */
     .tabcontent {
-      position: relative;      
-      padding: 6px 12px;
+      padding: 0px 12px;
       border: 1px solid #ccc;
       border-top: none;
-      height:90%;
-      overflow:scroll
+      overflow: auto;
+      position: absolute;
+      top: 40px;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      box-sizing: border-box;
     }
     input[type=range] {
         width:99%;
     }
 
-  
+    .tabcontent h3{
+      height: 25px;
+    }
+   .tabcontent .container{
+      position:absolute;
+      top: 65px;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
 </style>

--- a/vue/ota.vue
+++ b/vue/ota.vue
@@ -9,6 +9,7 @@
             <br/>
             <button :disabled="!otadata" @click="startota(null, $event)">Start quick OTA (delete all LittleFS data)</button>
             <br/>
+            <br/>
             <button @click="backup(null, $event)">Read fsblock</button>
             <button @click="reboot(null, $event)">Reboot</button>
             <button @click="restore(null, $event)">Restore fsblock</button>


### PR DESCRIPTION
This request has a bunch of small fixes and improvements which should make the app more better aligned.

These are the main issues which it addresses:
* Multiple scrollbars:
![image](https://user-images.githubusercontent.com/6459774/198858985-ce78a9a9-45a7-4a6c-b08d-70b9fab8f75e.png)
![image](https://user-images.githubusercontent.com/6459774/198859002-8f0e16ef-c86f-4813-bf97-3c9438292823.png)
* Misaligned elements in Logs bottom region
![image](https://user-images.githubusercontent.com/6459774/198859021-af5b33e7-9761-4da7-b591-b7cd86b19a01.png)

This is after the changes:
![image](https://user-images.githubusercontent.com/6459774/198859102-ca69c875-7229-483c-862a-a7cef04b812e.png)
![image](https://user-images.githubusercontent.com/6459774/198859074-5d4418e0-978a-4993-8622-e1b17b81a634.png)

It also
* Assigns fixed font to all elements for consistent look.
* Assigns consistent width to pins
 ![image](https://user-images.githubusercontent.com/6459774/198859117-4b4d0b7d-09b3-479c-bf7c-ea0a17127887.png)
* Provides clear indicator of paused logging
  ![image](https://user-images.githubusercontent.com/6459774/198859088-1473a401-d3fa-43bc-9116-978f4412e210.png)
* Removed : from Log names, sorted them and moved checkbox before the label.
![image](https://user-images.githubusercontent.com/6459774/198887109-6bab8ffe-2a19-4a2a-b562-1b16ca3dc695.png)



Probably still more improvements could be made but I thought this was a good start.

[openshwprojects](https://github.com/OpenBekenIOT/webapp/commits?author=openshwprojects) 