### PR TITLE
Update devices.json with QIACHIP boards

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -2,6 +2,65 @@
   "version": 0.1,
   "devices": [
     {
+      "vendor": "TROLINK",
+      "bDetailed": "0",
+      "name": "Smart IOT control board",
+      "model": "SM-028_V1.3",
+      "chip": "BL602",
+      "board": "SM-028_V1.3",
+      "pins": {
+        "1":  "Button;1",
+        "2":  "Button;2",
+        "3":  "Button;3",
+        "4":  "Button;4",
+        "14": "Button;5"
+        "17": "Button;6"
+        "20": "Button;7"
+        "21": "Button;8"
+        "22": "Button;9"
+      },
+      "keywords": ["", ""],
+      "image": "https://user-images.githubusercontent.com/14217781/209668900-bb520a07-8e79-45ce-a03a-ca0936ad0034.jpg",
+      "wiki": ""
+      "product": "https://world.taobao.com/item/691740234866.htm"
+    },
+    {
+      "vendor": "QIACHIP",
+      "bDetailed": "0",
+      "name": "WiFi DIY Relay",
+      "model": "KR05-1CHKG-W",
+      "chip": "BL602",
+      "board": "SM-028_V1.3",
+      "pins": {
+        "20": "Relay;1",
+        "4":  "Button;1",
+        "22": "WifiLED_n;1",
+      },
+      "keywords": ["switch","relay","KR05"],
+      "image": "https://user-images.githubusercontent.com/14217781/209668900-bb520a07-8e79-45ce-a03a-ca0936ad0034.jpg",
+      "wiki": ""
+      "product": "https://aliexpress.com/item/1005004996247436.html"
+    },
+    {
+      "vendor": "QIACHIP",
+      "bDetailed": "0",
+      "name": "WiFi DIY dual Switch",
+      "model": "KR0548-2CH-W",
+      "chip": "BL602",
+      "board": "SM-028_V1.3",
+      "pins": {
+        "21": "Relay;1",
+        "20": "Button;1",
+        "17": "Relay;2",
+        "4":  "Button;2",
+        "14": "WifiLED_n;1",
+      },
+      "keywords": ["switch","relay","KR0548"],
+      "image": "https://user-images.githubusercontent.com/14217781/209668935-4cb93644-7656-4b5e-a41b-515674f8ce0e.jpg",
+      "wiki": ""
+      "product": "https://aliexpress.com/item/1005004920914830.html"
+    },
+    {
       "vendor": "Generic",
       "bDetailed": "1",
       "name": "WiFi DIY Switch",

--- a/devices.json
+++ b/devices.json
@@ -13,15 +13,15 @@
         "2":  "Button;2",
         "3":  "Button;3",
         "4":  "Button;4",
-        "14": "Button;5"
-        "17": "Button;6"
-        "20": "Button;7"
-        "21": "Button;8"
+        "14": "Button;5",
+        "17": "Button;6",
+        "20": "Button;7",
+        "21": "Button;8",
         "22": "Button;9"
       },
       "keywords": ["", ""],
       "image": "https://user-images.githubusercontent.com/14217781/209668900-bb520a07-8e79-45ce-a03a-ca0936ad0034.jpg",
-      "wiki": ""
+      "wiki": "",
       "product": "https://world.taobao.com/item/691740234866.htm"
     },
     {
@@ -34,11 +34,11 @@
       "pins": {
         "20": "Relay;1",
         "4":  "Button;1",
-        "22": "WifiLED_n;1",
+        "22": "WifiLED_n;1"
       },
       "keywords": ["switch","relay","KR05"],
       "image": "https://user-images.githubusercontent.com/14217781/209668900-bb520a07-8e79-45ce-a03a-ca0936ad0034.jpg",
-      "wiki": ""
+      "wiki": "",
       "product": "https://aliexpress.com/item/1005004996247436.html"
     },
     {
@@ -53,11 +53,11 @@
         "20": "Button;1",
         "17": "Relay;2",
         "4":  "Button;2",
-        "14": "WifiLED_n;1",
+        "14": "WifiLED_n;1"
       },
       "keywords": ["switch","relay","KR0548"],
       "image": "https://user-images.githubusercontent.com/14217781/209668935-4cb93644-7656-4b5e-a41b-515674f8ce0e.jpg",
-      "wiki": ""
+      "wiki": "",
       "product": "https://aliexpress.com/item/1005004920914830.html"
     },
     {

--- a/devices.json
+++ b/devices.json
@@ -20,7 +20,7 @@
         "22": "Button;9"
       },
       "keywords": ["", ""],
-      "image": "https://user-images.githubusercontent.com/14217781/209668900-bb520a07-8e79-45ce-a03a-ca0936ad0034.jpg",
+      "image": "https://user-images.githubusercontent.com/14217781/209668729-d62d290f-33c7-4bda-9696-7a16734e841a.jpg",
       "wiki": "",
       "product": "https://world.taobao.com/item/691740234866.htm"
     },


### PR DESCRIPTION
![TROLINK SM-028_V1.3 BL602L20](https://user-images.githubusercontent.com/14217781/209668729-d62d290f-33c7-4bda-9696-7a16734e841a.jpg)
```
TROLINK SM-028_V1.3 BL602L20
LABEL GPIO       PIN
-------------------------
L     GPIO_1     2
A     GPIO_4     5
B     GPIO_20    29
G     GPIO_14    22
R     GPIO_3     4
22    GPIO_22    31
17    GPIO_17    28
C     GPIO_21    30
W     GPIO_2     3
```
---
![QIACHIP KR05-1CHKG-W](https://user-images.githubusercontent.com/14217781/209668900-bb520a07-8e79-45ce-a03a-ca0936ad0034.jpg)
```
QIACHIP KR05-1CHKG-W (SM-028_V1.3 BL602L20)
-------------------------
Btn       -> GPIO_14 (G)
Rel       -> GPIO_20 (B)
WifiLED_n -> GPIO_22 (22)
```
---
![QIACHIP KR0548-2CH-W](https://user-images.githubusercontent.com/14217781/209668935-4cb93644-7656-4b5e-a41b-515674f8ce0e.jpg)
```
QIACHIP KR0548-2CH-W (SM-028_V1.3 BL602L20)
-------------------------
Btn(1)    -> GPIO_20 (B)
Rel(1)    -> GPIO_21 (C)
Btn(2)    -> GPIO_4  (A)
Rel(2)    -> GPIO_17 (17)
WifiLED_n -> GPIO_14 (G)
```