### PR TITLE
Present applicable littleFS flash options, handle obkdevicelist error

### DIFF
--- a/vue/info.vue
+++ b/vue/info.vue
@@ -162,7 +162,10 @@
                 if (!this.releases.length){
                   this.getReleases();
                 }
-                this.getPeers();
+                //Only if chip supplied supportsSSDP=true or did not supply it at all (backward compatibility)
+                if (res.supportsSSDP === undefined || res.supportsSSDP === 1){
+                  this.getPeers();
+                }
             })
             .catch(err => {
               this.error = err.toString();

--- a/vue/ota.vue
+++ b/vue/ota.vue
@@ -5,20 +5,26 @@
             <p>Build: {{build}}</p>
         </div>
         <div>
-            <button :disabled="!otadata" @click="sequence(null, $event)">Start safe OTA (keep LittleFS data)</button>
-            <br/>
-            <button :disabled="!otadata" @click="startota(null, $event)">Start quick OTA (delete all LittleFS data)</button>
-            <br/>
-            <br/>
-            <button @click="backup(null, $event)">Read fsblock</button>
-            <button @click="reboot(null, $event)">Reboot</button>
-            <button @click="restore(null, $event)">Restore fsblock</button>
-            <select v-model="defaultaction">
-                <option value=''>Do nothing</option>
-                <option value='ota'>OTA Only</option>
-                <option value='sequence'>Backup/OTA/Restore</option>
-            </select>
-            <span>Selected: {{ defaultaction }}</span>
+            <span v-if="supportsLittleFS">
+                <button :disabled="!otadata" @click="sequence(null, $event)">Start safe OTA (keep LittleFS data)</button>
+                <br/>
+                <button :disabled="!otadata" @click="startota(null, $event)">Start quick OTA (delete all LittleFS data)</button>
+                <br/>
+                <br/>
+                <button @click="backup(null, $event)">Read fsblock</button>
+                <button @click="reboot(null, $event)">Reboot</button>
+                <button @click="restore(null, $event)">Restore fsblock</button>
+                <select v-model="defaultaction">
+                    <option value=''>Do nothing</option>
+                    <option value='ota'>OTA Only</option>
+                    <option value='sequence'>Backup/OTA/Restore</option>
+                </select>
+                <span>Selected: {{ defaultaction }}</span>
+            </span>
+            <span v-else>
+                <button :disabled="!otadata" @click="startota(null, $event)">Start OTA</button>
+                <button @click="reboot(null, $event)">Reboot</button>
+            </span>
             <br/>
             <br/>
             <span>Select remote OTA file to download to PC:</span>
@@ -62,6 +68,7 @@
         releases: [],
         options: [],
         selectedfile: '',
+        supportsLittleFS: false,
       }
     },
     methods:{
@@ -82,6 +89,12 @@
 
                     if (this.chipset){
                         this.otaFileExtension = this.chipSetUsesRBL() ? ".rbl" : ".img";
+                        
+                        //These chips don't support litte FS
+                        if (",W600,W800,XR809,BL602".indexOf(`,${this.chipset},`) !== -1)
+                        {
+                            this.supportsLittleFS = false;
+                        }
                     }
                 })
                 .catch(err => {


### PR DESCRIPTION
This PR helps with 2 things

1. Present flashing options only which relate to the chip.. don't present LitteFS restore/backup options if the chip doesn't support it yet.

Current appearance:
![image](https://user-images.githubusercontent.com/6459774/210227481-74dd668b-c786-47c7-a1c4-1481d7b4beb8.png)

And with changes:
![image](https://user-images.githubusercontent.com/6459774/210227533-729d7b03-dab8-49fb-b82b-6fedd10db54b.png)

2. Handle the `obkdevicelist` error more gracefully by not make the request. This could happen if the chip is on older firmware or if the chip not supporting SSDP or if SSDP is not running.
![image](https://user-images.githubusercontent.com/6459774/210226821-a9b87c39-3879-4db3-b393-f0a35584203a.png)

This would need matching changes from https://github.com/openshwprojects/OpenBK7231T_App/pull/577 to work completely. The behavior will be as before if the device does not have that change
```
//Only if chip supplied supportsSSDP=true or did not supply it at all (backward compatibility)
if (res.supportsSSDP === undefined || res.supportsSSDP === 1){
```