### PR TITLE
Added flags for FEIT LED Strip

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -5180,6 +5180,7 @@
       "model": "FETAPE/RGBW/CNTRSC",
       "chip": "BK7231N",
       "board": "LST04-BKN1",
+      "flags": "419698176",
       "keywords": [
         "RGBW",
         "Strip",


### PR DESCRIPTION
Previously flags were not being populated by Web App - now that this is fixed I have added them to the device config.