### PR TITLE
Add Tuya UNSH Mini Smart Switch SS8839-16A-W

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -5727,6 +5727,29 @@
 		"command": "",
 		"image": "https://obrazki.elektroda.pl/2041437300_1680860410.jpg",
 		"wiki": "https://www.elektroda.com/rtvforum/topic3970248.html"
-	}
+	},
+	{
+	  "vendor": "Tuya UNSH",
+	  "bDetailed": "0",
+	  "name": "Mini Smart Switch",
+	  "model": "SS8839-16A-W",
+	  "chip": "BK7231N",
+	  "board": "on PCB",
+	  "flags": "1024",
+	  "keywords": [
+	    "switch",
+	    "relay",
+	    "2-way"
+	  ],
+	  "pins": {
+	    "6": "TglChanOnTgl;0",
+	    "7": "Rel;0",
+	    "23": "Btn;0",
+	    "26": "LED;0"
+	  },
+	  "command": "",
+	  "image": "https://obrazki.elektroda.pl/7693204100_1681383448.jpg",
+	  "wiki": "https://www.elektroda.com/rtvforum/viewtopic.php?p=20524167"
+	}  
   ]
 }


### PR DESCRIPTION
Tuya UNSH Mini Smart Switch SS8839-16A-W with BK7231N on board
with  pins "6": "TglChanOnTgl;0", "7": "Rel;0", "23": "Btn;0", "26": "LED;0"