### PR TITLE
Add Smart Mini Switch Tuya UNSH EZB-WBZS1H16N-A

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -5727,6 +5727,29 @@
 		"command": "",
 		"image": "https://obrazki.elektroda.pl/2041437300_1680860410.jpg",
 		"wiki": "https://www.elektroda.com/rtvforum/topic3970248.html"
-	}
+	},
+	  {
+		  "vendor": "Tuya UNSH",
+		  "bDetailed": "0",
+		  "name": "Smart Mini Smart Switch",
+		  "model": "EZB-WBZS1H16N-A",
+		  "chip": "BK7231N",
+		  "board": "on PCB",
+		  "flags": "1024",
+		  "keywords": [
+		    "switch",
+		    "relay",
+		    "2-way"
+		  ],
+		  "pins": {
+		    "6": "LED_n;0",
+		    "8": "Btn;0",
+		    "14": "TglChanOnTgl;0",
+		    "15": "Rel;0"
+		  },
+		  "command": "",
+		  "image": "https://obrazki.elektroda.pl/7622004500_1681456492.jpg",
+		  "wiki": "https://www.elektroda.com/rtvforum/viewtopic.php?p=20538893#20538893"
+		}
   ]
 }


### PR DESCRIPTION
Smart Mini Switch Tuya UNSH EZB-WBZS1H16N-A with BK7321N on board with space for 433MHz and pins   "6": "LED_n;0", "8": "Btn;0", "14": "TglChanOnTgl;0", "15": "Rel;0"